### PR TITLE
Move to nri-spack

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -50,3 +50,5 @@ modules:
     load:
         - access-om3/2024.09.0
         - conda/analysis3-24.01
+
+payu_minimum_version: 1.1.4

--- a/config.yaml
+++ b/config.yaml
@@ -45,8 +45,8 @@ userscripts:
 
 modules:
     use:
-        - /g/data/ik11/spack/0.21.2/modules/access-om3/0.x.0/linux-rocky8-cascadelake
+        - /g/data/vk83/modules
         - /g/data/hh5/public/modules
     load:
-        - access-om3/96f91599f746b4866bbd3f05ee6eb192ba70d391_main
+        - access-om3/2024.09.0
         - conda/analysis3-24.01

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -2,7 +2,7 @@ format: yamanifest
 version: 1.0
 ---
 work/access-om3-MOM6-CICE6:
-  fullpath: /g/data/ik11/spack/0.21.2/opt/linux-rocky8-cascadelake/intel-2021.10.0/access-om3-96f91599f746b4866bbd3f05ee6eb192ba70d391_main-xva2u2s/bin/access-om3-MOM6-CICE6
+  fullpath: /g/data/vk83/apps/spack/0.22/release/linux-rocky8-x86_64/intel-2021.10.0/access-om3-nuopc-git.0.3.1_0.3.1-boks2tay6p2uqrv2y3wstcdqkotfs3d2/bin/access-om3-MOM6-CICE6
   hashes:
-    binhash: 7f416e7107222d69e8d08c3b90d16ec4
-    md5: 19309ecea53df718e7b84bd4cdacaab3
+    binhash: 324135533e9cd632f4a1be902022fbcc
+    md5: 553de82e4053fbb30bc1b25a053c8912


### PR DESCRIPTION
Move to nri-spack build. This is using the same access-om3 code and dependencies as the cosima-spack, although some build settings are different (e.g. the 'target' attribute). Its possible the performance is slightly different with this build.

The build still uses https://github.com/COSIMA/access-om3 for model components