### PR TITLE
`!test` Comment Command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ on:
       - config/**
       - .*
       - '*.md'
-      - README.md
   # For config-pr-2-confirm.yml and '!test' comment commands
   issue_comment:
     types:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
     permissions:
       contents: write  # for committing the result of the repro test
       pull-requests: write  # for writing comments on pull requests
+      checks: write # for adding a status badge next to the commit we are testing
 
   #################
   # Bump Tag jobs #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,8 @@ on:
       - config/**
       - .*
       - '*.md'
-  # For config-pr-2-confirm.yml
+      - README.md
+  # For config-pr-2-confirm.yml and '!test' comment commands
   issue_comment:
     types:
       - created
@@ -50,6 +51,15 @@ jobs:
     permissions:
       contents: write  # For updating metadata.yaml version and committing checksums
       pull-requests: write  # For commenting on PR
+
+  pr-comment-test:
+    name: !test
+    if: github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '!test')
+    uses: access-nri/model-config-tests/.github/workflows/config-comment-test.yml@main
+    secrets: inherit
+    permissions:
+      contents: write  # for committing the result of the repro test
+      pull-requests: write  # for writing comments on pull requests
 
   #################
   # Bump Tag jobs #


### PR DESCRIPTION
This PR introduces a PR comment-command of the form:
```
!test repro [commit]
```
which runs a repro test comparing the `HEAD` of the source (PR)  branch against the last common ancestor of the target (merged-into) branch, and optionally commits the result to the PR that the comment was found in. 

This allows repro checks to be run on any branch, rather than just being automatically run on `dev-*` -> `release-*` PRs. 

Appropriate safeguards have been taken so that the comment command will only work for users who have `write`/`admin` permissions on the PR they are commenting on. 

In this PR:
- **Add in job to handle `!test` comment commands**

Requires ACCESS-NRI/model-config-tests#73
References #120
