### PR TITLE
Migrate CI onto `dev-1deg_jra55do_iaf`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,73 @@
+name: CI
+run-name: CI (${{ github.event_name }}) for ${{ github.ref_name }}
+on:
+  # For config-pr-1-ci.yml
+  pull_request:
+    branches:
+      - 'release-*'
+      - 'dev-*'
+    paths-ignore:
+      # These are ignored because they don't have anything to do with the model itself
+      - .github/**
+      - doc/**
+      - config/**
+      - .*
+      - '*.md'
+  # For config-pr-2-confirm.yml and '!test' comment commands
+  issue_comment:
+    types:
+      - created
+      - edited
+  # For config-pr-3-bump-tag.yml
+  create:
+  push:
+    branches:
+      - 'release-*'
+    paths:
+      - 'metadata.yaml'
+jobs:
+  ###########
+  # PR jobs #
+  ###########
+  pr:
+    name: PR
+    if: github.event_name == 'pull_request' && github.repository != 'ACCESS-NRI/model-configs-template'
+    uses: access-nri/model-config-tests/.github/workflows/config-pr-1-ci.yml@main
+    secrets: inherit
+    permissions:
+      contents: write
+      pull-requests: write  # For pull request comments denoting failure of the workflow
+      checks: write  # For results of tests as a check
+
+  ###################
+  # PR Comment jobs #
+  ###################
+  pr-comment:
+    name: Comment
+    if: github.event_name == 'issue_comment' && github.repository != 'ACCESS-NRI/model-configs-template'
+    uses: access-nri/model-config-tests/.github/workflows/config-pr-2-confirm.yml@main
+    secrets: inherit
+    permissions:
+      contents: write  # For updating metadata.yaml version and committing checksums
+      pull-requests: write  # For commenting on PR
+
+  pr-comment-test:
+    name: !test
+    if: github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '!test')
+    uses: access-nri/model-config-tests/.github/workflows/config-comment-test.yml@main
+    secrets: inherit
+    permissions:
+      contents: write  # for committing the result of the repro test
+      pull-requests: write  # for writing comments on pull requests
+      checks: write # for adding a status badge next to the commit we are testing
+
+  #################
+  # Bump Tag jobs #
+  #################
+  bump-tag:
+    name: Tag Bump
+    if: (github.event_name == 'push' || github.event_name == 'create' && github.ref_type == 'branch' && startsWith(github.ref_name, 'release-')) && github.repository != 'ACCESS-NRI/model-configs-template'
+    uses: access-nri/model-config-tests/.github/workflows/config-pr-3-bump-tag.yml@main
+    secrets: inherit
+    permissions:
+      contents: write  # For creating a new release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       pull-requests: write  # For commenting on PR
 
   pr-comment-test:
-    name: !test
+    name: '!test'
     if: github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '!test')
     uses: access-nri/model-config-tests/.github/workflows/config-comment-test.yml@main
     secrets: inherit


### PR DESCRIPTION
In this PR, we add the `.github/workflows/ci.yml` file at `main` (specifically https://github.com/ACCESS-NRI/access-om3-configs/tree/a30ee6171164820efdfa50275620288f60465dbc/.github/workflows/ci.yml) to `dev-1deg_jra55do_iaf`. 

References #138
