### PR TITLE
Turn-off config CI checks until configs are further developed

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -12,7 +12,7 @@
     },
     "qa": {
         "default": {
-            "markers": "access_om3 or config"
+            "markers": "access_om3" # or config"
         }
     },
     "default": {

--- a/config/ci.json
+++ b/config/ci.json
@@ -12,7 +12,7 @@
     },
     "qa": {
         "default": {
-            "markers": "access_om3" # or config"
+            "markers": "access_om3"
         }
     },
     "default": {


### PR DESCRIPTION
Per #162, turn off config CI tests until these configurations are further developed.

This will allow progress on issues like https://github.com/ACCESS-NRI/access-om3-configs/pull/157