### PR TITLE
Update model-config-tests version

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -16,7 +16,7 @@
         }
     },
     "default": {
-        "model-config-tests-version": "0.0.9",
+        "model-config-tests-version": "0.0.11",
         "python-version": "3.11.0",
         "payu-version": "1.1.6"
     }


### PR DESCRIPTION
A fix has been added to `model-config-tests` to address https://github.com/COSIMA/access-om3/issues/265. This PR updates the version of `model-config-tests` used by the CI to include the fix.