### PR TITLE
Added 'checks: write' to model-configs-tests initial-checksums entrypoint

### DIFF
--- a/.github/workflows/generate-initial-checksums.yml
+++ b/.github/workflows/generate-initial-checksums.yml
@@ -74,4 +74,5 @@ jobs:
       payu-version: ${{ needs.config.outputs.payu-version }}
     permissions:
       contents: write
+      checks: write
     secrets: inherit


### PR DESCRIPTION
See failed run https://github.com/ACCESS-NRI/access-om3-configs/actions/runs/13254576757

This is due to the [updated structure](https://github.com/ACCESS-NRI/model-config-tests/pull/77) of `model-config-tests` requiring `checks: write` when it didn't need to before. This was missed in the linked PR. 

This PR adds `checks: write` to the entrypoint workflow, as required. 
