### PR TITLE
Add Scheduled Checks Workflow

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -1,0 +1,14 @@
+name: Scheduled Checks
+run-name: Scheduled Checks (${{ github.event_name }})
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'  # once a month
+jobs:
+  checks:
+    uses: access-nri/model-config-tests/.github/workflows/config-schedule-1-ci.yml@main
+    secrets: inherit
+    permissions:
+      checks: write
+      contents: write
+      issues: write


### PR DESCRIPTION
I'd realised that `access-om3-configs` doesn't actually have the `schedule.yml` workflow, so scheduled checks wouldn't run. 

This PR adds scheduled monthly repro checks for `access-om3-configs`, given there are entries in `configs/ci.json`. 
