### PR TITLE
Turn on restart reproducability for 1deg ryf

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -3,11 +3,23 @@
     "scheduled": {
         "default": {
             "markers": "checksum"
+        },
+        "dev-1deg_jra55do_ryf": {
+            "markers": "checksum or checksum_slow"
+        },
+        "release-1deg_jra55do_ryf": {
+            "markers": "checksum or checksum_slow"
         }
     },
     "reproducibility": {
         "default": {
             "markers": "checksum"
+        },
+        "dev-1deg_jra55do_ryf": {
+            "markers": "checksum or checksum_slow"
+        },
+        "release-1deg_jra55do_ryf": {
+            "markers": "checksum or checksum_slow"
         }
     },
     "qa": {

--- a/config/ci.json
+++ b/config/ci.json
@@ -2,14 +2,10 @@
     "$schema": "https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/configuration/ci/2-0-0.json",
     "scheduled": {
         "default": {
-            "markers": "checksum"
-        },
-        "dev-1deg_jra55do_ryf": {
             "markers": "checksum or checksum_slow"
         },
-        "release-1deg_jra55do_ryf": {
-            "markers": "checksum or checksum_slow"
-        }
+        "dev-1deg_jra55do_ryf": {},
+        "release-1deg_jra55do_ryf": {}
     },
     "reproducibility": {
         "default": {


### PR DESCRIPTION
This turns on two tests for the 1deg ryf branch.

One is that 2x1day runs give the same results as 1x2day run.
One is that 2x1days results from the same initial conditions give the same result.

Contributes to #41 

I have triggered the `checksum_slow` tests manually on gadi to confirm they run.