### PR TITLE
Restart reproducibility check

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -47,7 +47,7 @@ modules:
     use:
         - /g/data/vk83/prerelease/modules
     load:
-        - access-om3/pr49-6
+        - access-om3/pr49-8
         - nco/5.0.5
 
 payu_minimum_version: 1.1.6

--- a/config.yaml
+++ b/config.yaml
@@ -47,7 +47,7 @@ modules:
     use:
         - /g/data/vk83/prerelease/modules
     load:
-        - access-om3/pr49-9
+        - access-om3/pr49-10
         - nco/5.0.5
 
 payu_minimum_version: 1.1.6

--- a/config.yaml
+++ b/config.yaml
@@ -45,9 +45,9 @@ userscripts:
 
 modules:
     use:
-        - /g/data/vk83/modules
+        - /g/data/vk83/prerelease/modules
     load:
-        - access-om3/2025.01.0
+        - access-om3/pr49-1
         - nco/5.0.5
 
 payu_minimum_version: 1.1.6

--- a/config.yaml
+++ b/config.yaml
@@ -47,7 +47,7 @@ modules:
     use:
         - /g/data/vk83/prerelease/modules
     load:
-        - access-om3/pr49-3
+        - access-om3/pr49-5
         - nco/5.0.5
 
 payu_minimum_version: 1.1.6

--- a/config.yaml
+++ b/config.yaml
@@ -47,7 +47,7 @@ modules:
     use:
         - /g/data/vk83/prerelease/modules
     load:
-        - access-om3/pr49-2
+        - access-om3/pr49-3
         - nco/5.0.5
 
 payu_minimum_version: 1.1.6

--- a/config.yaml
+++ b/config.yaml
@@ -47,7 +47,7 @@ modules:
     use:
         - /g/data/vk83/prerelease/modules
     load:
-        - access-om3/pr49-8
+        - access-om3/pr49-9
         - nco/5.0.5
 
 payu_minimum_version: 1.1.6

--- a/config.yaml
+++ b/config.yaml
@@ -47,7 +47,7 @@ modules:
     use:
         - /g/data/vk83/prerelease/modules
     load:
-        - access-om3/pr49-5
+        - access-om3/pr49-6
         - nco/5.0.5
 
 payu_minimum_version: 1.1.6

--- a/config.yaml
+++ b/config.yaml
@@ -47,7 +47,7 @@ modules:
     use:
         - /g/data/vk83/prerelease/modules
     load:
-        - access-om3/pr49-1
+        - access-om3/pr49-2
         - nco/5.0.5
 
 payu_minimum_version: 1.1.6

--- a/fd.yaml
+++ b/fd.yaml
@@ -3,852 +3,950 @@
    institution: National ESPC, CSC & MCL Working Groups
    description: Community-based dictionary for shared coupling fields
    entries:
-      #
-      #-----------------------------------
-      # section: mediator export for atm/ocn flux calculation
-      #-----------------------------------
-      #
+     #
+     #-----------------------------------
+     # Current the following sections are below
+     # section: fields computed in med
+     # section: lnd import to med
+     # section: lnd export from med (computed in med)
+     # section: atm import to med
+     # section: atm export from med (computed in med)
+     # section: glc import to med
+     # section: glc export from med (computed in med)
+     # section: ice import to med
+     # section: ocn import to med
+     # section: ocn export from med (computed in med)
+     # section: river import to med
+     # section: river export from med (computed in med)
+     # section: wav import to med
+     #-----------------------------------
+     #
+     #-----------------------------------
+     # section: fields computed in med
+     #-----------------------------------
+     #
+     - standard_name: cpl_scalars
+       canonical_units: unitless
+     #
+     - standard_name: frac
+       canonical_units: 1
+     #
+     - standard_name: mask
+       canonical_units: 1
+     #
+     - standard_name: area
+       canonical_units: radians**2
+       description: med area for component
+     #
      - standard_name: Faox_evap
        alias: mean_evap_rate_atm_into_ocn
        canonical_units: kg m-2 s-1
-       description: mediator export - atm/ocn evaporation water flux
+       description: med export - atm/ocn evaporation water flux computed in medidator
      #
      - standard_name: Faox_evap_wiso
        canonical_units: kg m-2 s-1
-       description: mediator export - atm/ocn evaporation water flux 16O, 18O, HDO
+       description: med export - atm/ocn evaporation water flux 16O, 18O, HDO computed in medidator
      #
      - standard_name: Faox_lat
        alias: mean_laten_heat_flx_atm_into_ocn
        canonical_units: W m-2
-       description: mediator export - atm/ocn surface latent heat flux
+       description: med export - atm/ocn surface latent heat flux computed in medidator
      #
      - standard_name: Faox_sen
        alias: mean_sensi_heat_flx_atm_into_ocn
        canonical_units: W m-2
-       description: mediator export - atm/ocn surface sensible heat flux
+       description: med export - atm/ocn surface sensible heat flux computed in medidator
      #
      - standard_name: Faox_lwup
        alias: mean_up_lw_flx_ocn
        canonical_units: W m-2
-       description: mediator export - long wave radiation flux over the ocean
+       description: med export - ocn long wave radiation flux over the ocean computed in medidator
      #
      - standard_name: Faox_taux
        alias: stress_on_air_ocn_zonal
        canonical_units: N m-2
-       description: mediator export
+       description: med export - atm/ocn zonal surface stress computed in medidator
      #
      - standard_name: Faox_tauy
        alias: stress_on_air_ocn_merid
        canonical_units: N m-2
-       description: mediator export
+       description: med export - atm/ocn meridional surface stress computed in medidator
      #
-     - standard_name: area
-       canonical_units: radians**2
-       description: mediator area for component
+     - standard_name: Fwxx_taux
+       alias: mean_zonal_moment_flx
+       canonical_units: N m-2
+       description: wave import to med - zonal surface stress
+     #
+     - standard_name: Fwxx_tauy
+       alias: mean_merid_moment_flx
+       canonical_units: N m-2
+       description: wave import to med - meridional surface stress
      #
      #-----------------------------------
-     # section: land export
+     # section: lnd import to med
      #-----------------------------------
      #
      - standard_name: Fall_evap
        canonical_units: kg m-2 s-1
-       description: land export
+       description: lnd import to med
      #
      - standard_name: Fall_evap_wiso
        canonical_units: kg m-2 s-1
-       description: land export
+       description: lnd import to med
      #
      - standard_name: Fall_fco2_lnd
        canonical_units: moles m-2 s-1
-       description: land export
+       description: lnd import to med
      #
      - standard_name: Fall_fire
        canonical_units: kg/m2/sec
-       description: land export - wild fire emission fluxes (1->10)
+       description: lnd import to med - wild fire emission fluxes (1->10)
      #
      - standard_name: Fall_flxdst
        canonical_units: kg m-2 s-1
-       description: land export - dust fluxes from land (sizes 1->4)
+       description: lnd import to med - dust fluxes from lnd (sizes 1->4)
      #
      - standard_name: Fall_lat
        canonical_units: W m-2
-       description: land export
+       description: lnd import to med
      #
      - standard_name: Fall_lwup
        canonical_units: W m-2
-       description: land export
+       description: lnd import to med
      #
      - standard_name: Fall_sen
        canonical_units: W m-2
-       description: land export
+       description: lnd import to med
      #
      - standard_name: Fall_swnet
        canonical_units: W m-2
-       description: land export
+       description: lnd import to med
      #
      - standard_name: Fall_taux
        canonical_units: N m-2
-       description: land export
+       description: lnd import to med
      #
      - standard_name: Fall_tauy
        canonical_units: N m-2
-       description: land export
+       description: lnd import to med
      #
      - standard_name: Fall_voc
        canonical_units: molecules/m2/sec
-       description: land export - MEGAN voc emission fluxes from land (1->20)
+       description: lnd import to med - MEGAN voc emission fluxes from lnd (1->20)
      #
      - standard_name: Sl_anidf
        canonical_units: 1
-       description: land export
+       description: lnd import to med
      #
      - standard_name: Sl_anidr
        canonical_units: 1
-       description: land export
+       description: lnd import to med
      #
      - standard_name: Sl_avsdf
        canonical_units: 1
-       description: land export
+       description: lnd import to med
      #
      - standard_name: Sl_avsdr
        canonical_units: 1
-       description: land export
+       description: lnd import to med
      #
      - standard_name: Sl_ddvel
        canonical_units: cm/sec
-       description: land export - dry deposition velocities from (1->80)
+       description: lnd import to med - dry deposition velocities from (1->80)
      #
      - standard_name: Sl_fv
        canonical_units: m s-1
-       description: land export
+       description: lnd import to med
      #
      - standard_name: Sl_fztop
        canonical_units: m
-       description: land export
+       description: lnd import to med
      #
      - standard_name: Sl_lfrac
        canonical_units: 1
-       description: land export
+       description: lnd import to med
      #
      - standard_name: Sl_lfrin
        canonical_units: 1
-       description: land export
+       description: lnd import to med
      #
      - standard_name: Sl_qref
        canonical_units: kg kg-1
-       description: land export
+       description: lnd import to med
      #
      - standard_name: Sl_qref_wiso
        canonical_units: kg kg-1
-       description: land export
+       description: lnd import to med
      #
      - standard_name: Sl_ram1
        canonical_units: s/m
-       description: land export
+       description: lnd import to med
      #
      - standard_name: Sl_snowh
        canonical_units: m
-       description: land export
+       description: lnd import to med
      #
      - standard_name: Sl_snowh_wiso
        canonical_units: m
-       description: land export
+       description: lnd import to med
      #
      - standard_name: Sl_soilw
        canonical_units: m3/m3
-       description: land export
+       description: lnd import to med
      #
      - standard_name: Sl_t
        canonical_units: K
-       description: land export
+       description: lnd import to med
+     #
+     - standard_name: Flrl_irrig
+       canonical_units: kg m-2 s-1
+       description: lnd export to river
+     #
+     - standard_name: Flrl_rofdto
+       canonical_units: kg m-2 s-1
+       description: lnd export to river
+     #
+     - standard_name: Flrl_rofgwl
+       canonical_units: kg m-2 s-1
+       description: lnd export to river
+     #
+     - standard_name: Flrl_rofi
+       canonical_units: kg m-2 s-1
+       description: lnd export to river
+     #
+     - standard_name: Flrl_rofsub
+       canonical_units: kg m-2 s-1
+       description: lnd export to river
+     #
+     - standard_name: Flrl_rofsur
+       canonical_units: kg m-2 s-1
+       description: lnd export to river
      #
      - standard_name: Sl_topo_elev
        canonical_units: m
-       description: land export to mediator in elevation classes (1->glc_nec)
-     #
-     - standard_name: Sl_topo
-       canonical_units: m
-       description: mediator export to glc - no levation classes
+       description: lnd import to med with elevation classes (1->glc_nec)
      #
      - standard_name: Sl_tsrf_elev
        canonical_units: deg C
-       description: land export to mediator in elevation classes (1->glc_nec)
+       description: lnd import to med with elevation classes (1->glc_nec)
+     #
+     - standard_name: Flgl_qice_elev
+       canonical_units: kg m-2 s-1
+       description: lnd import to med in elevation classes (1->glc_nec)
+     #
+     #-----------------------------------
+     # section: lnd export from med (computed in med)
+     #-----------------------------------
+     #
+     - standard_name: Sl_topo
+       canonical_units: m
+       description: lnd export from med with no elevation classes (computed in med)
      #
      - standard_name: Sl_tsrf
        canonical_units: deg C
-       description: mediator export to gcl with no elevation classes
+       description: lnd export from med with no elevation classes (computed in med)
      #
      - standard_name: Sl_tref
        canonical_units: K
-       description: mediator export to glc - no levation classes
+       description: lnd export from med with no elevation classes (computed in med)
      #
      - standard_name: Sl_u10
        canonical_units: m
-       description: land export
+       description: lnd import to med with no elevation classes (computed in med)
+     #
+     - standard_name: Flgl_qice
+       canonical_units: kg m-2 s-1
+       description: lnd export to med no elevation classes (computed in med)
      #
      #-----------------------------------
-     # section: atmosphere export
+     # section: atm import to med
      #-----------------------------------
      #
      - standard_name: Faxa_nhx
        canonical_units: kg m-2 s-1
-       description: atmosphere export
+       description: atm import to med
      #
      - standard_name: Faxa_noy
        canonical_units: kg m-2 s-1
-       description: atmosphere export
+       description: atm import to med
      #
      - standard_name: Faxa_bcph
        canonical_units: kg m-2 s-1
-       description: atmosphere export
+       description: atm import to med
      #
      - standard_name: Faxa_ocph
        canonical_units: kg m-2 s-1
-       description: atmosphere export
+       description: atm import to med
      #
      - standard_name: Faxa_dstdry
        canonical_units: kg m-2 s-1
-       description: atmosphere export
+       description: atm import to med
      #
      - standard_name: Faxa_dstwet
        canonical_units: kg m-2 s-1
-       description: atmosphere export
+       description: atm import to med
      #
      - standard_name: Faxa_swdn
        alias: mean_down_sw_flx
        canonical_units: W m-2
-       description: atmosphere export
+       description: atm import to med
          mean downward SW heat flux
      #
      - standard_name: Faxa_lwdn
        alias: mean_down_lw_flx
        canonical_units: W m-2
-       description: atmosphere export
+       description: atm import to med
          mean downward SW heat flux
      #
      - standard_name: Faxa_ndep
        canonical_units: kg(N)/m2/sec
-       description: atmosphere export to land and ocean - currently nhx and noy
+       description: atm import to med - currently nhx and noy
      #
      - standard_name: Faxa_prec_wiso
        canonical_units: kg m-2 s-1
-       description: atmosphere export
+       description: atm import to med
      #
      - standard_name: Faxa_rain
        alias: mean_prec_rate
        canonical_units: kg m-2 s-1
-       description: atmosphere export
+       description: atm import to med
      #
      - standard_name: Faxa_rain_wiso
        alias: mean_prec_rate_wiso
        canonical_units: kg m-2 s-1
-       description: atmosphere export
+       description: atm import to med
      #
      - standard_name: Faxa_rainc
        canonical_units: kg m-2 s-1
-       description: atmosphere export
+       description: atm import to med
      #
      - standard_name: Faxa_rainc_wiso
        canonical_units: kg m-2 s-1
-       description: atmosphere export
+       description: atm import to med
      #
      - standard_name: Faxa_rainl
        canonical_units: kg m-2 s-1
-       description: atmosphere export
+       description: atm import to med
      #
      - standard_name: Faxa_rainl_wiso
        canonical_units: kg m-2 s-1
-       description: atmosphere export
+       description: atm import to med
      #
      - standard_name: Faxa_snow
        alias: mean_fprec_rate
        canonical_units: kg m-2 s-1
-       description: atmosphere export
+       description: atm import to med
      #
      - standard_name: Faxa_snow_wiso
        canonical_units: kg m-2 s-1
-       description: atmosphere export
+       description: atm import to med
      #
      - standard_name: Faxa_snowc
        canonical_units: kg m-2 s-1
-       description: atmosphere export
+       description: atm import to med
      #
      - standard_name: Faxa_snowc_wiso
        canonical_units: kg m-2 s-1
-       description: atmosphere export
+       description: atm import to med
      #
      - standard_name: Faxa_snowl
        canonical_units: kg m-2 s-1
-       description: atmosphere export
+       description: atm import to med
      #
      - standard_name: Faxa_snowl_wiso
        canonical_units: kg m-2 s-1
-       description: atmosphere export
+       description: atm import to med
      #
      - standard_name: Faxa_swnet
        canonical_units: W m-2
-       description: atmosphere export
+       description: atm import to med
      #
      - standard_name: Faxa_lwnet
        canonical_units: W m-2
-       description: atmosphere export
+       description: atm import to med
      #
      - standard_name: Faxa_swndf
        alias: mean_down_sw_ir_dif_flx
        canonical_units: W m-2
-       description: atmosphere export - mean surface downward nir diffuse flux
+       description: atm import to med - mean surface downward nir diffuse flux
      #
      - standard_name: Faxa_swndr
        alias: mean_down_sw_ir_dir_flx
        canonical_units: W m-2
-       description: atmosphere export - mean surface downward nir direct flux
+       description: atm import to med - mean surface downward nir direct flux
      #
      - standard_name: Faxa_swvdf
        alias: mean_down_sw_vis_dif_flx
        canonical_units: W m-2
-       description: atmosphere export - mean surface downward uv+vis diffuse flux
+       description: atm import to med - mean surface downward uv+vis diffuse flux
      #
      - standard_name: Faxa_swvdr
        alias: mean_down_sw_vis_dir_flx
        canonical_units: W m-2
-       description: atmosphere export - mean surface downward uv+visvdirect flux
+       description: atm import to med - mean surface downward uv+visvdirect flux
      #
      - standard_name: Sa_co2diag
        canonical_units: 1e-6 mol/mol
-       description: atmosphere export - diagnostic CO2 at the lowest model level
+       description: atm import to med - diagnostic CO2 at the lowest model level
      #
      - standard_name: Sa_co2prog
        canonical_units: 1e-6 mol/mol
-       description: atmosphere export - prognostic CO2 at the lowest model level
+       description: atm import to med - prognostic CO2 at the lowest model level
      #
      - standard_name: Sa_o3
        canonical_units: mol/mol
-       description: atmosphere export - O3 in the lowest model layer (prognosed or prescribed)
+       description: atm import to med - O3 in the lowest model layer (prognosed or prescribed)
      #
      - standard_name: Sa_lightning
        canonical_units: /min
-       description: atmosphere export - lightning flash freqency
+       description: atm import to med - lightning flash freqency
      #
      - standard_name: Sa_topo
        alias: inst_surface_height
        canonical_units: m
-       description: atmosphere export - topographic height
+       description: atm import to med - topographic height
      #
      - standard_name: Sa_dens
        alias: air_density_height_lowest
        canonical_units: kg m-3
-       description: atmosphere export - density at the lowest model layer
+       description: atm import to med - density at the lowest model layer
      #
      - standard_name: Sa_pbot
        alias: inst_pres_height_lowest
        canonical_units: Pa
-       description: atmosphere export - pressure at lowest model layer
+       description: atm import to med - pressure at lowest model layer
      #
      - standard_name: Sa_pslv
        alias: inst_pres_height_surface
        canonical_units: Pa
-       description: atmosphere export
+       description: atm import to med
      #
      - standard_name: Sa_ptem
        canonical_units: K
-       description: atmosphere export - bottom layer potential temperature
+       description: atm import to med - bottom layer potential temperature
      #
      - standard_name: Sa_shum
        alias: inst_spec_humid_height_lowest
        canonical_units: kg kg-1
-       description: atmosphere export - bottom layer specific humidity
+       description: atm import to med - bottom layer specific humidiaty
      #
      - standard_name: Sa_shum_wiso
        alias: inst_spec_humid_height_lowest_wiso
        canonical_units: kg kg-1
-       description: atmosphere export - bottom layer specific humidity 16O, 18O, HDO
+       description: atm import to med - bottom layer specific humidity 16O, 18O, HDO
      #
      - standard_name: Sa_tbot
        alias: inst_temp_height_lowest
        canonical_units: K
-       description: atmosphere export - bottom layer temperature
+       description: atm import to med - bottom layer temperature
      #
      - standard_name: Sa_tskn
        alias: inst_temp_skin_temperature
        canonical_units: K
-       description: atmosphere export - sea surface skin temperature
+       description: atm import to med - sea surface skin temperature
      #
      - standard_name: Sa_u
        alias: inst_zonal_wind_height_lowest
        canonical_units: m s-1
-       description: atmosphere export - bottom layer zonal wind
+       description: atm import to med - bottom layer zonal wind
      #
      - standard_name: Sa_v
        alias: inst_merid_wind_height_lowest
        canonical_units: m s-1
-       description: atmosphere export - bottom layer meridional wind
+       description: atm import to med - bottom layer meridional wind
+     #
+     - standard_name: Sa_u10m
+       canonical_units: m s-1
+       description: atm import to med - 10m zonal wind
+     #
+     - standard_name: Sa_v10m
+       canonical_units: m s-1
+       description: atm import to med- 10m meridional wind
      #
      - standard_name: Sa_wspd
        alias: inst_wind_speed_height_lowest
        canonical_units: m s-1
-       description: atmosphere export - bottom layer wind speed
+       description: atm import to med - bottom layer wind speed
      #
      - standard_name: Sa_z
        alias: inst_height_lowest
        canonical_units: m
-       description: atmosphere export - bottom layer height
+       description: atm import to med - bottom layer height
      #
      - standard_name: Faxa_taux
        alias: mean_zonal_moment_flx_atm
        canonical_units: N m-2
-       description: atmosphere export - zonal component of momentum flux
+       description: atm import to med - zonal component of momentum flux
      #
      - standard_name: Faxa_tauy
        alias: mean_merid_moment_flx_atm
        canonical_units: N m-2
-       description: atmosphere export - meridional component of momentum flux
+       description: atm import to med - meridional component of momentum flux
      #
      - standard_name: Faxa_lat
        alias: mean_laten_heat_flx_atm
        canonical_units: W m-2
-       description: atmosphere export
+       description: atm import to med
      #
      - standard_name: Faxa_sen
        alias: mean_sensi_heat_flx_atm
        canonical_units: W m-2
-       description: atmosphere export
+       description: atm import to med
      #
      #-----------------------------------
-     # section: atmosphere import
+     # section: atm export from med (computed in med)
      #-----------------------------------
      #
      - standard_name: Faxx_evap
        canonical_units: kg m-2 s-1
-       description: to atm merged water evaporation flux
+       description: atm export from meditor - merged water evaporation flux
      #
      - standard_name: Faxx_evap_wiso
        canonical_units: kg m-2 s-1
-       description: to atm merged water evaporation flux for 16O, 18O and HDO
+       description: atm export from med - merged water evaporation flux for 16O, 18O and HDO
      #
      - standard_name: Faxx_lat
        alias: mean_laten_heat_flx
        canonical_units: W m-2
-       description: to to atm merged latent heat flux
+       description: atm export from med -  merged latent heat flux
      #
      - standard_name: Faxx_lwup
        canonical_units: W m-2
-       description: to atm merged outgoing longwave radiation
+       description: atm export from med -  merged outgoing longwave radiation
      #
      - standard_name: Faxx_sen
        alias: mean_sensi_heat_flx
        canonical_units: W m-2
-       description: to atm merged sensible heat flux
+       description: atm export from med -  merged sensible heat flux
      #
      - standard_name: Faxx_taux
        alias: mean_zonal_moment_flx
        canonical_units: N m-2
-       description: to atm merged zonal surface stress
+       description: atm export from med -  merged zonal surface stress
      #
      - standard_name: Faxx_tauy
        alias: mean_merid_moment_flx
        canonical_units: N m-2
-       description: to atm merged meridional surface stress
+       description: atm export from med -  merged meridional surface stress
      #
      - standard_name: Sx_anidf
        canonical_units: 1
-       description: atmosphere import
-       description: to atm merged surface diffuse albedo (near-infrared radiation)
+       description: atm export from med -  merged surface diffuse albedo (near-infrared radiation)
      #
      - standard_name: Sx_anidr
        canonical_units: 1
-       description: to atm merged direct surface albedo (near-infrared radiation)
+       description: atm export from med -  merged direct surface albedo (near-infrared radiation)
      #
      - standard_name: Sx_avsdf
        canonical_units: 1
-       description: to atm merged surface diffuse albedo (visible radation)
+       description: atm export from med -  merged surface diffuse albedo (visible radation)
      #
      - standard_name: Sx_avsdr
        canonical_units: 1
-       description: to atm merged direct surface albedo (visible radiation)
+       description: atm export from med -  merged direct surface albedo (visible radiation)
      #
      - standard_name: Sx_qref
        canonical_units: kg kg-1
-       description: atmosphere import
+       description: atm export from med
      #
      - standard_name: Sx_qref_wiso
        canonical_units: kg kg-1
-       description: atmosphere import
+       description: atm export from med
      #
      - standard_name: Sx_t
        alias: surface_temperature
        canonical_units: K
-       description: atmosphere import
+       description: atm export from med
      #
      - standard_name: Sx_tref
        canonical_units: K
-       description: atmosphere import
+       description: atm export from med
      #
      - standard_name: Sx_u10
        canonical_units: m
-       description: atmosphere import
+       description: atm export from med
      #
      - standard_name: So_ugustOut
        canonical_units: m/s
-       description: atmosphere import
+       description: atm export from med
      #
      - standard_name: So_u10withGust
        canonical_units: m/s
-       description: atmosphere import
+       description: atm export from med
      #
      - standard_name: So_u10res
        canonical_units: m/s
-       description: atmosphere import
+       description: atm export from med
      #
      #-----------------------------------
-     # section: land-ice export
+     # section: glc import to med
+     #-----------------------------------
+     #
      # Note that the fields sent from glc->med do NOT have elevation classes,
      # but the fields from med->lnd are broken into multiple elevation classes
-     #-----------------------------------
+     #
+     - standard_name: Fgrg_rofi
+       canonical_units: kg m-2 s-1
+       description: glc import tomed - glacier frozen_runoff_flux_to_ocean
+     #
+     - standard_name: Fgrg_rofi_wiso
+       canonical_units: kg m-2 s-1
+       description: glc import to med - glacier_frozen_runoff_flux_to_ocean for 16O, 18O, HDO
+     #
+     - standard_name: Fgrg_rofl
+       canonical_units: kg m-2 s-1
+       description: glc import to med - glacier liquid runoff flux to ocean
+     #
+     - standard_name: Fgrg_rofl_wiso
+       canonical_units: kg m-2 s-1
+       description: glc import to med - glacier_frozen_runoff_flux_to_ocean for 16O, 18O, HDO
      #
      - standard_name: Figg_rofi
        canonical_units: kg m-2 s-1
-       description: land-ice export - glc frozen runoff_iceberg flux to ice
+       description: glc import to med - glc frozen runoff_iceberg flux to ice
      #
      - standard_name: Figg_rofi_wiso
        canonical_units: kg m-2 s-1
-       description: land-ice export - glc frozen runoff_iceberg flux to ice for 16O, 18O, HDO
+       description: glc import to med - glc frozen runoff_iceberg flux to ice for 16O, 18O, HDO
      #
      - standard_name: Flgg_hflx
        canonical_units: W m-2
-       description: land-ice export to mediator (no elevation classes)
-         Downward heat flux from glacier interior, from mediator, elev class 0
-     #
-     - standard_name: Flgg_hflx_elev
-       canonical_units: W m-2
-       description: mediator land-ice export to lnd (elevation classes 1->glc_nec)
-         Downward heat flux from glacier interior, from mediator, elev class 1->glc_nec
+       description: glc import to med to med (no elevation classes)
+         Downward heat flux from glacier interior, from med, elev class 0
      #
      - standard_name: Sg_area
        canonical_units: area internal to the CISM grid in radians**2
-       description: land-ice export to mediator (no elevation classes)
+       description: glc import to med to med (no elevation classes)
      #
      - standard_name: Sg_ice_covered
        canonical_units: 1
-       description: land-ice export to mediator (no elevation classes)
-     #
-     - standard_name: Sg_ice_covered_elev
-       canonical_units: 1
-       description: mediator land-ice export to lnd (elevation classes 1->glc_nec)
+       description: glc import to med (no elevation classes)
      #
      - standard_name: Sg_icemask
        canonical_units: 1
-       description: land-ice export
+       description: glc import to med
      #
      - standard_name: Sg_icemask_coupled_fluxes
        canonical_units: 1
-       description: land-ice export
+       description: glc import to med
      #
      - standard_name: Sg_topo
        canonical_units: m
-       description: land-ice export to mediator (no elevation classes)
+       description: glc import to med (no elevation classes)
+     #
+     #-----------------------------------
+     # section: glc export from med (computed in med)
+     #-----------------------------------
+     #
+     - standard_name: Flgg_hflx_elev
+       canonical_units: W m-2
+       description: glc export from med (elevation classes 1->glc_nec)
+         Downward heat flux from glacier interior, from med, elev class 1->glc_nec
+     #
+     - standard_name: Sg_ice_covered_elev
+       canonical_units: 1
+       description: glc export from med (elevation classes 1->glc_nec)
      #
      - standard_name: Sg_topo_elev
        canonical_units: m
-       description: mediator land-ice export to lnd (elevation classes 1->glc_nec)
-     #
-     - standard_name: Fogg_rofi
-       canonical_units: kg m-2 s-1
-       description: land-ice export - glacier_frozen_runoff_flux_to_ocean
-     #
-     - standard_name: Fogg_rofi_wiso
-       canonical_units: kg m-2 s-1
-       description: land-ice export - glacier_frozen_runoff_flux_to_ocean for 16O, 18O, HDO
-     #
-     - standard_name: Fogg_rofl
-       canonical_units: kg m-2 s-1
-       description: land-ice export - glacier liquid runoff flux to ocean
-     #
-     - standard_name: Fogg_rofl_wiso
-       canonical_units: kg m-2 s-1
-       description: land-ice export - glacier_frozen_runoff_flux_to_ocean for 16O, 18O, HDO
+       description: glc export from med (elevation classes 1->glc_nec)
      #
      #-----------------------------------
-     # section: sea-ice export
+     # section: ice import to med
      #-----------------------------------
      #
      - standard_name: Faii_evap
        alias: mean_evap_rate_atm_into_ice
        canonical_units: kg m-2 s-1
-       description: sea-ice export
+       description: ice import to med
      #
      - standard_name: Faii_evap_wiso
        canonical_units: kg m-2 s-1
-       description: sea-ice export for 16O, 18O, HDO
+       description: ice import to med for 16O, 18O, HDO
      #
      - standard_name: Faii_lat
        alias: mean_laten_heat_flx_atm_into_ice
        canonical_units: W m-2
-       description: sea-ice export to atm - atm/ice latent heat flux
+       description: ice import to med - atm/ice latent heat flux
      #
      - standard_name: Faii_sen
        alias: mean_sensi_heat_flx_atm_into_ice
        canonical_units: W m-2
-       description: sea-ice export to atm - atm/ice sensible heat flux
+       description: ice import to med - atm/ice sensible heat flux
      #
      - standard_name: Faii_lwup
        alias: mean_up_lw_flx_ice
        canonical_units: W m-2
-       description: sea-ice export -outgoing logwave radiation
+       description: ice import to med -outgoing logwave radiation
      #
      - standard_name: Faii_swnet
        canonical_units: W m-2
-       description: sea-ice export to atm
+       description: ice import to med to atm
      #
      - standard_name: Faii_taux
        alias: stress_on_air_ice_zonal
        canonical_units: N m-2
-       description: sea-ice export to atm - air ice zonal stress
+       description: ice import to med - air ice zonal stress
      #
      - standard_name: Faii_tauy
        alias: stress_on_air_ice_merid
        canonical_units: N m-2
-       description: sea-ice export - air ice meridional stress
+       description: ice import to med - air ice meridional stress
      #
      - standard_name: Fioi_bcphi
        canonical_units: kg m-2 s-1
-       description: sea-ice export to ocean - hydrophilic black carbon flux to ocean
+       description: ice import to med to ocean - hydrophilic black carbon flux to ocean
      #
      - standard_name: Fioi_bcpho
        canonical_units: kg m-2 s-1
-       description: sea-ice export to ocean - hydrophobic black carbon flux to ocean
+       description: ice import to med to ocean - hydrophobic black carbon flux to ocean
      #
      - standard_name: Fioi_flxdst
        canonical_units: kg m-2 s-1
-       description: sea-ice export to ocean - dust aerosol flux to ocean
+       description: ice import to med to ocean - dust aerosol flux to ocean
      #
      - standard_name: Fioi_melth
        alias: net_heat_flx_to_ocn
        canonical_units: W m-2
-       description: sea-ice export to ocean - net heat flux to ocean
+       description: ice import to med to ocean - net heat flux to ocean
      #
      - standard_name: Fioi_melth_wiso
        canonical_units: kg m-2 s-1
-       description: sea-ice export to ocean - isotope head flux to ocean for 16O, 18O, HDO
+       description: ice import to med to ocean - isotope head flux to ocean for 16O, 18O, HDO
      #
      - standard_name: Fioi_melth_HDO
        canonical_units: kg m-2 s-1
-       description: sea-ice export to ocean - isotope head flux to ocean
+       description: ice import to med to ocean - isotope head flux to ocean
      #
      - standard_name: Fioi_meltw
        alias: mean_fresh_water_to_ocean_rate
        canonical_units: kg m-2 s-1
-       description: sea-ice export to ocean - fresh water to ocean (h2o flux from melting)
+       description: ice import to med to ocean - fresh water to ocean (h2o flux from melting)
      #
      - standard_name: Fioi_meltw_wiso
        alias: mean_fresh_water_to_ocean_rate_wiso
        canonical_units: kg m-2 s-1
-       description: sea-ice export to ocean - fresh water to ocean (h2o flux from melting) for 16O, 18O, HDO
+       description: ice import to med to ocean - fresh water to ocean (h2o flux from melting) for 16O, 18O, HDO
      #
      - standard_name: Fioi_salt
        alias: mean_salt_rate
        canonical_units: kg m-2 s-1
-       description: sea-ice export to ocean - salt to ocean (salt flux from melting)
+       description: ice import to med - salt to ocean (salt flux from melting)
      #
      - standard_name: Fioi_swpen
        alias: mean_sw_pen_to_ocn
        canonical_units: W m-2
-       description: sea-ice export to ocean - flux of shortwave through ice to ocean
+       description: ice import to med - flux of shortwave through ice to ocean
      #
      - standard_name: Fioi_swpen_vdr
        alias: mean_sw_pen_to_ocn_vis_dir_flx
        canonical_units: W m-2
-       description: sea-ice export to ocean - flux of vis dir shortwave through ice to ocean
+       description: ice import to med - flux of vis dir shortwave through ice to ocean
      #
      - standard_name: Fioi_swpen_vdf
        alias: mean_sw_pen_to_ocn_vis_dif_flx
        canonical_units: W m-2
-       description: sea-ice export to ocean - flux of vif dir shortwave through ice to ocean
+       description: ice import to med - flux of vif dir shortwave through ice to ocean
      #
      - standard_name: Fioi_swpen_idr
        alias: mean_sw_pen_to_ocn_ir_dir_flx
        canonical_units: W m-2
-       description: sea-ice export to ocean - flux of ir dir shortwave through ice to ocean
+       description: ice import to med - flux of ir dir shortwave through ice to ocean
      #
      - standard_name: Fioi_swpen_idf
        alias: mean_sw_pen_to_ocn_ir_dif_flx
        canonical_units: W m-2
-       description: sea-ice export to ocean - flux of ir dif shortwave through ice to ocean
+       description: ice import to med - flux of ir dif shortwave through ice to ocean
      #
      - standard_name: Fioi_taux
        alias: stress_on_ocn_ice_zonal
        canonical_units: N m-2
-       description: sea-ice export to ocean - ice ocean zonal stress
+       description: ice import to med - ice ocean zonal stress
      #
      - standard_name: Fioi_tauy
        alias: stress_on_ocn_ice_merid
        canonical_units: N m-2
-       description: sea-ice export to ocean - ice ocean meridional stress
+       description: ice import to med - ice ocean meridional stress
      #
      - standard_name: Si_anidf
        alias: inst_ice_ir_dif_albedo
        canonical_units: 1
-       description: sea-ice export to atm
+       description: ice import to med
      #
      - standard_name: Si_anidr
        alias: inst_ice_ir_dir_albedo
        canonical_units: 1
-       description: sea-ice export to atm
+       description: ice import to med
      #
      - standard_name: Si_avsdf
        alias: inst_ice_vis_dif_albedo
        canonical_units: 1
-       description: sea-ice export to atm
+       description: ice import to med
      #
      - standard_name: Si_avsdr
        alias: inst_ice_vis_dir_albedo
        canonical_units: 1
-       description: sea-ice export to atm
+       description: ice import to med
      #
      - standard_name: Si_ifrac
        alias: ice_fraction
        canonical_units: 1
-       description: sea-ice export to atm
-         ice fraction (varies with time)
+       description: ice import to med - ice fraction (varies with time)
      #
      - standard_name: Si_ifrac_n
        alias: ice_fraction_n
        canonical_units: 1
-       description: sea-ice export - ice fraction per category (varies with time)
+       description: ice import to med - ice fraction per category (varies with time)
      #
      - standard_name: Si_imask
        alias: ice_mask
        canonical_units: 1
-       description: sea-ice export - ice mask
+       description: ice import to med - ice mask
      #
      - standard_name: Si_qref
        canonical_units: kg kg-1
-       description: sea-ice export to atm
+       description: ice import to med
      #
      - standard_name: Si_qref_wiso
        canonical_units: kg kg-1
-       description: sea-ice export to atm
+       description: ice import to med
      #
      - standard_name: Si_t
        alias: sea_ice_surface_temperature
        canonical_units: K
-       description: sea-ice export
+       description: ice import to med
      #
      - standard_name: Si_tref
        canonical_units: K
-       description: sea-ice export
+       description: ice import to med
      #
      - standard_name: Si_u10
        canonical_units: m
-       description: sea-ice export
+       description: ice import to med
      #
      - standard_name: Si_vice
        alias: mean_ice_volume
        canonical_units: m
-       description: sea-ice export
-         volume of ice per unit area
+       description: ice import to med - volume of ice per unit area
      #
      - standard_name: Si_snowh
        canonical_units: m
-       description: sea-ice export - surface_snow_water_equivalent
+       description: ice import to med - surface_snow_water_equivalent
      #
      - standard_name: Si_vsno
        alias: mean_snow_volume
        canonical_units: m
-       description: sea-ice export - volume of snow per unit area
+       description: ice import to med - volume of snow per unit area
      #
      - standard_name: Si_thick
        canonical_units: m
-       description: sea-ice export - ice thickness
+       description: ice import to med - ice thickness
      #
      - standard_name: Si_floediam
        canonical_units: m
-       description: sea-ice export - ice floe diameter
+       description: ice import to med - ice floe diameter
        #
      #-----------------------------------
-     # section: ocean export to mediator
+     # section: ocn import to med
      #-----------------------------------
      #
      - standard_name: Fioo_q
        alias: freezing_melting_potential
        canonical_units: W m-2
-       description: ocean export
+       description: ocn import to med
      #
      - standard_name: Faoo_fco2_ocn
        canonical_units: moles m-2 s-1
-       description: ocean export
+       description: ocn import to med - surface flux of CO2 (downward positive)
+     #
+     - standard_name: Faoo_fdms_ocn
+       canonical_units: moles m-2 s-1
+       description: ocn import to med - surface flux of DMS (downward positive)
+     #
+     - standard_name: Faoo_fbrf_ocn
+       canonical_units: moles m-2 s-1
+       description: ocn import to med - surface flux of Bromoform (downward positive)
+     #
+     - standard_name: Faoo_fn2o_ocn
+       canonical_units: moles m-2 s-1
+       description: ocn import to med - surface flux of N2O (downward positive)
+     #
+     - standard_name: Faoo_fnh3_ocn
+       canonical_units: moles m-2 s-1
+       description: ocn import to med - surface flux of NH3 (downward positive)
      #
      - standard_name: So_anidf
        canonical_units: 1
-       description: ocean export
+       description: ocn import to med
      #
      - standard_name: So_anidr
        canonical_units: 1
-       description: ocean export
+       description: ocn import to med
      #
      - standard_name: So_avsdf
        canonical_units: 1
-       description: ocean export
+       description: ocn import to med
      #
      - standard_name: So_avsdr
        canonical_units: 1
-       description: ocean export
+       description: ocn import to med
      #
      - standard_name: So_bldepth
        alias: mixed_layer_depth
        canonical_units: m
-       description: ocean export
+       description: ocn import to med
      #
      - standard_name: So_dhdx
        alias: sea_surface_slope_zonal
        canonical_units: m m-1
-       description: ocean export
+       description: ocn import to med
      #
      - standard_name: So_dhdy
        alias: sea_surface_slope_merid
        canonical_units: m m-1
-       description: ocean export
+       description: ocn import to med
      #
      - standard_name: So_duu10n
        canonical_units: m2 s-2
-       description: ocean export
+       description: ocn import to med
      #
      - standard_name: So_fswpen
        canonical_units: 1
-       description: ocean export
+       description: ocn import to med
      #
      - standard_name: So_ofrac
        canonical_units: 1
-       description: ocean export
+       description: ocn import to med
      #
      - standard_name: So_omask
        alias: ocean_mask
        canonical_units: 1
-       description: ocean export
+       description: ocn import to med
      #
      - standard_name: So_qref
        canonical_units: kg kg-1
-       description: ocean export
+       description: ocn import to med
      #
      - standard_name: So_qref_wiso
        canonical_units: kg kg-1
-       description: ocean export
+       description: ocn import to med
      #
      - standard_name: So_re
        canonical_units: 1
-       description: ocean export
+       description: ocn import to med
      #
      - standard_name: So_qref_wiso
        canonical_units: kg kg-1
-       description: ocean export
+       description: ocn import to med
      #
      - standard_name: So_roce_wiso
        canonical_units: unitless
-       description: ocean export
+       description: ocn import to med
      #
      - standard_name: So_s
        alias: s_surf
        canonical_units: g kg-1
-       description: ocean export
+       description: ocn import to med
      #
      - standard_name: So_s_depth
        alias: s_surf_depths
@@ -857,12 +955,12 @@
      #
      - standard_name: So_ssq
        canonical_units: kg kg-1
-       description: ocean export
+       description: ocn import to med
      #
      - standard_name: So_t
        alias: sea_surface_temperature
        canonical_units: K
-       description: ocean export
+       description: ocn import to med
      #
      - standard_name: So_t_depth
        alias: sea_surface_temperature_depths
@@ -871,292 +969,254 @@
      #
      - standard_name: So_tref
        canonical_units: K
-       description: ocean export
+       description: ocn import to med
      #
      - standard_name: So_u
        alias: ocn_current_zonal
        canonical_units: m s-1
-       description: ocean export
+       description: ocn import to med
      #
      - standard_name: So_u10
        canonical_units: m
-       description: ocean export
+       description: ocn import to med
      #
      - standard_name: So_ustar
        canonical_units: m s-1
-       description: ocean export
+       description: ocn import to med
      #
      - standard_name: So_v
        alias: ocn_current_merid
        canonical_units: m s-1
-       description: ocean export
+       description: ocn import to med
      #
      #-----------------------------------
-     # section: river export
-     #-----------------------------------
-     #
-     - standard_name: Firr_rofi
-       canonical_units: kg m-2 s-1
-       description: river export - water flux into sea ice due to runoff (frozen)
-     #
-     - standard_name: Firr_rofi_wiso
-       canonical_units: kg m-2 s-1
-       description: river export - water flux into sea ice due to runoff (frozen) for 16O, 18O, HDO
-     #
-     - standard_name: Fixx_rofi
-       canonical_units: kg m-2 s-1
-       description: frozen runoff to ice from river and land-ice
-     #
-     - standard_name: Fixx_rofi_wiso
-       canonical_units: kg m-2 s-1
-       description: frozen runoff to ice from river and land-ice for 16O, 18O, HDO
-     #
-     #-----------------------------------
-     # section: lnd export to glc
-     #-----------------------------------
-     #
-     - standard_name: Flgl_qice
-       canonical_units: kg m-2 s-1
-       description: mediator export to glc no elevation classes
-     #
-     - standard_name: Flgl_qice_elev
-       canonical_units: kg m-2 s-1
-       description: land export to mediator  in elevation classes (1->glc_nec)
-     #
-     #-----------------------------------
-     # section: lnd export to river
-     #-----------------------------------
-     #
-     - standard_name: Flrl_irrig
-       canonical_units: kg m-2 s-1
-       description: land export to river
-     #
-     - standard_name: Flrl_rofdto
-       canonical_units: kg m-2 s-1
-       description: land export to river
-     #
-     - standard_name: Flrl_rofgwl
-       canonical_units: kg m-2 s-1
-       description: land export to river
-     #
-     - standard_name: Flrl_rofi
-       canonical_units: kg m-2 s-1
-       description: land export to river
-     #
-     - standard_name: Flrl_rofsub
-       canonical_units: kg m-2 s-1
-       description: land export to river
-     #
-     - standard_name: Flrl_rofsur
-       canonical_units: kg m-2 s-1
-       description: land export to river
-     #
-     #-----------------------------------
-     # section: river export
-     #-----------------------------------
-     #
-     - standard_name: Flrr_flood
-       canonical_units: kg m-2 s-1
-       description: river export to land - water flux due to flooding
-     #
-     - standard_name: Flrr_flood_wiso
-       canonical_units: kg m-2 s-1
-       description: river export to land - water flux due to flooding for 16O, 18O, HDO
-     #
-     - standard_name: Flrr_volr
-       canonical_units: m
-       description: river export to land - river channel total water volume
-     #
-     - standard_name: Flrr_volr_wiso
-       canonical_units: m
-       description: river export to land - river channel total water volume from 16O, 18O, HDO
-     #
-     - standard_name: Flrr_volrmch
-       canonical_units: m
-       description: river export to land - river channel main channel water volume
-     #
-     - standard_name: Flrr_volrmch_wiso
-       canonical_units: m
-       description: river export to land - river channel main channel water volume from 16O, 18O, HDO
-     #
-     - standard_name: Sr_tdepth
-       canonical_units: m
-       description: river export to land - tributary channel water depth
-     #
-     - standard_name: Sr_tdepth_max
-       canonical_units: m
-       description: river export to land - tributary channel bankfull depth
-     #
-     - standard_name: Forr_rofi
-       canonical_units: kg m-2 s-1
-       description: river export to ocean - water flux due to runoff (frozen)
-     #
-     - standard_name: Forr_rofi_wiso
-       canonical_units: kg m-2 s-1
-       description: river export to ocean - water flux due to runoff (frozen) for 16O, 18O, HDO
-     #
-     - standard_name: Forr_rofl
-       canonical_units: kg m-2 s-1
-       description: river export to ocean - water flux due to runoff (liquid)
-     #
-     - standard_name: Forr_rofl_wiso
-       canonical_units: kg m-2 s-1
-       description: river export to ocean - water flux due to runoff (frozen) for 16O, 18O, HDO
-     #
-     #-----------------------------------
-     # section: ocean import
+     # section: ocn export from med (computed in med)
      #-----------------------------------
      #
      - standard_name: Foxx_hrain
        alias: heat_content_lprec
        canonical_units: W m-2
-       description: to ocn heat content of rain
+       description: med export to ocn heat content of rain
      #
      - standard_name: Foxx_hsnow
        alias: heat_content_fprec
        canonical_units: W m-2
-       description: to ocn heat content of snow
+       description: med export to ocn heat content of snow
      #
      - standard_name: Foxx_hevap
        alias: heat_content_evap
        canonical_units: W m-2
-       description: to ocn heat content of evaporation
+       description: med export to ocn heat content of evaporation
      #
      - standard_name: Foxx_hcond
        alias: heat_content_cond
        canonical_units: W m-2
-       description: to ocn heat content of condensation
+       description: med export to ocn heat content of condensation
      #
      - standard_name: Foxx_hrofl
        alias: heat_content_rofl
        canonical_units: W m-2
-       description: to ocn heat content of liquid runoff
+       description: med export to ocn heat content of liquid runoff
      #
      - standard_name: Foxx_hrofi
        alias: heat_content_rofi
        canonical_units: W m-2
-       description: to ocn heat content of ice runoff
+       description: med export to ocn heat content of ice runoff
+     #
+     - standard_name: Foxx_hrofl_glc
+       alias: heat_content_rofl_glc
+       canonical_units: W m-2
+       description: med export to ocn heat content of liquid glc runoff
+     #
+     - standard_name: Foxx_hrofi_glc
+       alias: heat_content_rofi_glc
+       canonical_units: W m-2
+       description: med export to ocn heat content of ice glc runoff
      #
      - standard_name: Foxx_evap
        alias: mean_evap_rate
        canonical_units: kg m-2 s-1
-       description: ocean import - specific humidity flux
+       description: med export to ocn - specific humidity flux
      #
      - standard_name: Foxx_evap_wiso
        alias: mean_evap_rate_wiso
        canonical_units: kg m-2 s-1
-       description: ocean import - specific humidity flux 16O, 18O, HDO
+       description: med export to ocn - specific humidity flux 16O, 18O, HDO
      #
      - standard_name: Foxx_lat
        canonical_units: W m-2
-       description: ocean import - latent heat flux into ocean
+       description: med export to ocn - latent heat flux into ocean
      #
      - standard_name: Foxx_lat_wiso
        canonical_units: W m-2
-       description: ocean import - latent heat flux into ocean for 16O, 18O, HDO
+       description: med export to ocn - latent heat flux into ocean for 16O, 18O, HDO
      #
      - standard_name: Foxx_lat
        canonical_units: W m-2
-       description: ocean import - latent heat flux into ocean for HDO
+       description: med export to ocn - latent heat flux into ocean for HDO
      #
      - standard_name: Foxx_sen
        alias: mean_sensi_heat_flx
        canonical_units: W m-2
-       description: ocean import - sensible heat flux into ocean
+       description: med export to ocn - sensible heat flux into ocean
      #
      - standard_name: Foxx_lwup
        canonical_units: W m-2
-       description: ocean import - surface upward longwave heat flux
+       description: med export to ocn - surface upward longwave heat flux
      #
      - standard_name: Foxx_lwnet
        alias: mean_net_lw_flx
        canonical_units: W m-2
-       description: ocean import - mean NET long wave radiation flux to ocean
+       description: med export to ocn - mean NET long wave radiation flux to ocean
      #
      - standard_name: mean_runoff_rate
        canonical_units: kg m-2 s-1
-       description: ocean import - total runoff to ocean
+       description: med export to ocn - total runoff to ocean
      #
      - standard_name: mean_runoff_heat_flux
        canonical_units: kg m-2 s-1
-       description: ocean import - heat content of runoff
+       description: med export to ocn - heat content of runoff
      #
      - standard_name: mean_calving_rate
        canonical_units: kg m-2 s-1
-       description: ocean import - total calving to ocean
+       description: med export to ocn - total calving to ocean
      #
      - standard_name: mean_calving_heat_flux
        canonical_units: kg m-2 s-1
-       description: ocean import - heat content of calving
+       description: med export to ocn - heat content of calving
      #
      - standard_name: Foxx_rofi
        canonical_units: kg m-2 s-1
-       description: ocean import - water flux due to runoff (frozen)
+       description: med export to ocn - water flux due to runoff (frozen)
      #
      - standard_name: Foxx_rofi_wiso
        canonical_units: kg m-2 s-1
-       description: ocean import - water flux due to runoff (frozen) for 16O, 18O, HDO
+       description: med export to ocn - water flux due to runoff (frozen) for 16O, 18O, HDO
      #
      - standard_name: Foxx_rofl
        alias: mean_runoff_rate
        canonical_units: kg m-2 s-1
-       description: ocean import - water flux due to runoff (liquid)
+       description: med export to ocn - water flux due to runoff (liquid)
      #
      - standard_name: Foxx_rofl_wiso
        canonical_units: kg m-2 s-1
-       description: ocean import - water flux due to runoff (liquid) for 16O, 18O, HDO
+       description: med export to ocn - water flux due to runoff (liquid) for 16O, 18O, HDO
      #
      - standard_name: Foxx_swnet
        alias: mean_net_sw_flx
        canonical_units: W m-2
-       description: ocean import - net shortwave radiation to ocean
+       description: med export to ocn - net shortwave radiation to ocean
      #
      - standard_name: Foxx_swnet_vdr
        alias: mean_net_sw_vis_dir_flx
        canonical_units: W m-2
-       description: ocean import - net shortwave visible direct radiation to ocean
+       description: med export to ocn - net shortwave visible direct radiation to ocean
      #
      - standard_name: Foxx_swnet_vdf
        alias: mean_net_sw_vis_dif_flx
        canonical_units: W m-2
-       description: ocean import - net shortwave visible diffuse radiation to ocean
+       description: med export to ocn - net shortwave visible diffuse radiation to ocean
      #
      - standard_name: Foxx_swnet_idr
        alias: mean_net_sw_ir_dir_flx
        canonical_units: W m-2
-       description: ocean import - net shortwave ir direct radiation to ocean
+       description: med export to ocn - net shortwave ir direct radiation to ocean
      #
      - standard_name: Foxx_swnet_idf
        alias: mean_net_sw_ir_dif_flx
        canonical_units: W m-2
-       description: ocean import - net shortwave ir diffuse radiation to ocean
+       description: med export to ocn - net shortwave ir diffuse radiation to ocean
      #
      - standard_name: Foxx_swnet_afracr
        canonical_units: W m-2
-       description: ocean import - net shortwave radiation times atmosphere fraction
+       description: med export to ocn - net shortwave radiation times atmosphere fraction
      #
      - standard_name: Foxx_taux
        alias: mean_zonal_moment_flx
        canonical_units: N m-2
-       description: ocean import - zonal surface stress
+       description: med export to ocn - zonal surface stress
      #
      - standard_name: Foxx_tauy
        alias: mean_merid_moment_flx
        canonical_units: N m-2
-       description: ocean import - meridional surface stress
+       description: med export to ocn - meridional surface stress
      #
      - standard_name: Fioi_swpen_ifrac_n
        alias: mean_sw_pen_to_ocn_ifrac_n
        canonical_units: W m-2
-       description: ocean import - net shortwave radiation penetrating into ice and ocean times ice fraction for thickness category 1
+       description: med export to ocn - net shortwave radiation penetrating into ice and ocean times ice fraction for thickness category 1
      #
      - standard_name: Sf_afrac
        canonical_units: 1
-       description: ocean import - fractional atmosphere coverage wrt ocean
+       description: med export to ocn - fractional atmosphere coverage wrt ocean
      #
      - standard_name: Sf_afracr
        canonical_units: 1
-       description: ocean import - fractional atmosphere coverage used in radiation computations wrt ocean
+       description: med export to ocn - fractional atmosphere coverage used in radiation computations wrt ocean
+     #
+     #-----------------------------------
+     # section: river import to med
+     #-----------------------------------
+     #
+     - standard_name: Flrr_flood
+       canonical_units: kg m-2 s-1
+       description: river import to med - water flux due to flooding
+     #
+     - standard_name: Flrr_flood_wiso
+       canonical_units: kg m-2 s-1
+       description: river import to med - water flux due to flooding for 16O, 18O, HDO
+     #
+     - standard_name: Flrr_volr
+       canonical_units: m
+       description: river import to med - river channel total water volume
+     #
+     - standard_name: Flrr_volr_wiso
+       canonical_units: m
+       description: river import to med - river channel total water volume from 16O, 18O, HDO
+     #
+     - standard_name: Flrr_volrmch
+       canonical_units: m
+       description: river import to med - river channel main channel water volume
+     #
+     - standard_name: Flrr_volrmch_wiso
+       canonical_units: m
+       description: river import to med - river channel main channel water volume from 16O, 18O, HDO
+     #
+     - standard_name: Sr_tdepth
+       canonical_units: m
+       description: river import to med - tributary channel water depth
+     #
+     - standard_name: Sr_tdepth_max
+       canonical_units: m
+       description: river import to med - tributary channel bankfull depth
+     #
+     - standard_name: Forr_rofi
+       canonical_units: kg m-2 s-1
+       description: river export to ocean - water flux due to runoff (frozen)
+     #
+     - standard_name: Forr_rofi_glc
+       canonical_units: kg m-2 s-1
+       description: river export to ocean - water flux due to runoff originating from glc (frozen)
+     #
+     - standard_name: Forr_rofi_wiso
+       canonical_units: kg m-2 s-1
+       description: river import to med - water flux due to runoff (frozen) for 16O, 18O, HDO
+     #
+     - standard_name: Forr_rofl
+       canonical_units: kg m-2 s-1
+       description: river import to med - water flux due to runoff (liquid)
+     #
+     - standard_name: Forr_rofl_glc
+       canonical_units: kg m-2 s-1
+       description: river import to med - water flux due to runoff originating from glc (liquid)
+     #
+     - standard_name: Forr_rofl_wiso
+       canonical_units: kg m-2 s-1
+       description: river import to med - water flux due to runoff (frozen) for 16O, 18O, HDO
+     #
+     #-----------------------------------
+     # section: wav import to med
+     #-----------------------------------
      #
      - standard_name: Sw_hstokes
        canonical_units: m
@@ -1181,37 +1241,76 @@
      - standard_name: Sw_pstokes_y
        canonical_units: m/s
        description: Northward partitioned stokes drift components
-
      #
      - standard_name: Sw_elevation_spectrum
        alias: wave_elevation_spectrum
        canonical_units: m2/s
        description: wave elevation spectrum
-
      #
-     #-----------------------------------
-     # section: wave import
-     #-----------------------------------
+     - standard_name: Sw_ustokes_avg
+       canonical_units: m/s
+       description: Daily averaged stokes drift u component (only needed for med history output)
      #
-     - standard_name: Fwxx_taux
-       alias: mean_zonal_moment_flx
-       canonical_units: N m-2
-       description: wave import - zonal surface stress
+     - standard_name: Sw_vstokes_avg
+       canonical_units: m/s
+       description: Daily averaged stokes drift v component (only needed for med history output)
      #
-     - standard_name: Fwxx_tauy
-       alias: mean_merid_moment_flx
-       canonical_units: N m-2
-       description: wave import - meridional surface stress
-
-     #-----------------------------------
-     # mediator fields
-     #-----------------------------------
+     - standard_name: Sw_hs_avg
+       canonical_units: m
+       description: Daily averaged significant wave hight (only needed for med history output)
      #
-     - standard_name: cpl_scalars
-       canonical_units: unitless
+     - standard_name: Sw_phs0_avg
+       canonical_units: m
+       description: Daily averaged averaged wind sea swh (only needed for med history output)
      #
-     - standard_name: frac
-       canonical_units: 1
+     - standard_name: Sw_phs1_avg
+       canonical_units: m
+       description: Daily averaged swell swh (only needed for med history output)
      #
-     - standard_name: mask
-       canonical_units: 1
+     - standard_name: Sw_pdir0_avg
+       canonical_units: degrees
+       description: Daily averaged wind sea swh (only needed for med history output)
+     #
+     - standard_name: Sw_pdir1_avg
+       canonical_units: degrees
+       description: Daily averaged swell swh (only needed for med history output)
+     #
+     - standard_name: Sw_pTm10_avg
+       canonical_units: s
+       description: Daily averaged wind sea mean wave Tm1 period (only needed for med history output)
+     #
+     - standard_name: Sw_pTm11_avg
+       canonical_units: s
+       description: Daily average swell mean wave Tm1 period (only needed for med history output)
+     #
+     - standard_name: Sw_Tm1_avg
+       canonical_units: s
+       description: Daily averaged mean wave period of the first moment (only needed for med history output)
+     #
+     - standard_name: Sw_thm_avg
+       canonical_units: degrees
+       description: Daily averaged mean wave direction (only needed for med history output)
+     #
+     - standard_name: Sw_thp0_avg
+       canonical_units: degrees
+       description: Daily averaged peak wave direction (only needed for med history output)
+     #
+     - standard_name: Sw_fp0_avg
+       canonical_units: 1/s
+       description: Daily averaged peak wave frequency (only needed for med history output)
+     #
+     - standard_name: Sw_u_avg
+       canonical_units: m/s
+       description: Daily averaged surface wind zonal (only needed for med history output)
+     #
+     - standard_name: Sw_v_avg
+       canonical_units: m/s
+       description: Daily averaged surface wind meridional (only needed for med history output)
+     #
+     - standard_name: Sw_tusx_avg
+       canonical_units: m2/s
+       description: Daily averaged stokes zonal transport vector (only needed for med history output)
+     #
+     - standard_name: Sw_tusy_avg
+       canonical_units: m2/s
+       description: Daily averaged stokes meridional transport vector (only needed for med history output)

--- a/fd.yaml
+++ b/fd.yaml
@@ -3,950 +3,852 @@
    institution: National ESPC, CSC & MCL Working Groups
    description: Community-based dictionary for shared coupling fields
    entries:
-     #
-     #-----------------------------------
-     # Current the following sections are below
-     # section: fields computed in med
-     # section: lnd import to med
-     # section: lnd export from med (computed in med)
-     # section: atm import to med
-     # section: atm export from med (computed in med)
-     # section: glc import to med
-     # section: glc export from med (computed in med)
-     # section: ice import to med
-     # section: ocn import to med
-     # section: ocn export from med (computed in med)
-     # section: river import to med
-     # section: river export from med (computed in med)
-     # section: wav import to med
-     #-----------------------------------
-     #
-     #-----------------------------------
-     # section: fields computed in med
-     #-----------------------------------
-     #
-     - standard_name: cpl_scalars
-       canonical_units: unitless
-     #
-     - standard_name: frac
-       canonical_units: 1
-     #
-     - standard_name: mask
-       canonical_units: 1
-     #
-     - standard_name: area
-       canonical_units: radians**2
-       description: med area for component
-     #
+      #
+      #-----------------------------------
+      # section: mediator export for atm/ocn flux calculation
+      #-----------------------------------
+      #
      - standard_name: Faox_evap
        alias: mean_evap_rate_atm_into_ocn
        canonical_units: kg m-2 s-1
-       description: med export - atm/ocn evaporation water flux computed in medidator
+       description: mediator export - atm/ocn evaporation water flux
      #
      - standard_name: Faox_evap_wiso
        canonical_units: kg m-2 s-1
-       description: med export - atm/ocn evaporation water flux 16O, 18O, HDO computed in medidator
+       description: mediator export - atm/ocn evaporation water flux 16O, 18O, HDO
      #
      - standard_name: Faox_lat
        alias: mean_laten_heat_flx_atm_into_ocn
        canonical_units: W m-2
-       description: med export - atm/ocn surface latent heat flux computed in medidator
+       description: mediator export - atm/ocn surface latent heat flux
      #
      - standard_name: Faox_sen
        alias: mean_sensi_heat_flx_atm_into_ocn
        canonical_units: W m-2
-       description: med export - atm/ocn surface sensible heat flux computed in medidator
+       description: mediator export - atm/ocn surface sensible heat flux
      #
      - standard_name: Faox_lwup
        alias: mean_up_lw_flx_ocn
        canonical_units: W m-2
-       description: med export - ocn long wave radiation flux over the ocean computed in medidator
+       description: mediator export - long wave radiation flux over the ocean
      #
      - standard_name: Faox_taux
        alias: stress_on_air_ocn_zonal
        canonical_units: N m-2
-       description: med export - atm/ocn zonal surface stress computed in medidator
+       description: mediator export
      #
      - standard_name: Faox_tauy
        alias: stress_on_air_ocn_merid
        canonical_units: N m-2
-       description: med export - atm/ocn meridional surface stress computed in medidator
+       description: mediator export
      #
-     - standard_name: Fwxx_taux
-       alias: mean_zonal_moment_flx
-       canonical_units: N m-2
-       description: wave import to med - zonal surface stress
-     #
-     - standard_name: Fwxx_tauy
-       alias: mean_merid_moment_flx
-       canonical_units: N m-2
-       description: wave import to med - meridional surface stress
+     - standard_name: area
+       canonical_units: radians**2
+       description: mediator area for component
      #
      #-----------------------------------
-     # section: lnd import to med
+     # section: land export
      #-----------------------------------
      #
      - standard_name: Fall_evap
        canonical_units: kg m-2 s-1
-       description: lnd import to med
+       description: land export
      #
      - standard_name: Fall_evap_wiso
        canonical_units: kg m-2 s-1
-       description: lnd import to med
+       description: land export
      #
      - standard_name: Fall_fco2_lnd
        canonical_units: moles m-2 s-1
-       description: lnd import to med
+       description: land export
      #
      - standard_name: Fall_fire
        canonical_units: kg/m2/sec
-       description: lnd import to med - wild fire emission fluxes (1->10)
+       description: land export - wild fire emission fluxes (1->10)
      #
      - standard_name: Fall_flxdst
        canonical_units: kg m-2 s-1
-       description: lnd import to med - dust fluxes from lnd (sizes 1->4)
+       description: land export - dust fluxes from land (sizes 1->4)
      #
      - standard_name: Fall_lat
        canonical_units: W m-2
-       description: lnd import to med
+       description: land export
      #
      - standard_name: Fall_lwup
        canonical_units: W m-2
-       description: lnd import to med
+       description: land export
      #
      - standard_name: Fall_sen
        canonical_units: W m-2
-       description: lnd import to med
+       description: land export
      #
      - standard_name: Fall_swnet
        canonical_units: W m-2
-       description: lnd import to med
+       description: land export
      #
      - standard_name: Fall_taux
        canonical_units: N m-2
-       description: lnd import to med
+       description: land export
      #
      - standard_name: Fall_tauy
        canonical_units: N m-2
-       description: lnd import to med
+       description: land export
      #
      - standard_name: Fall_voc
        canonical_units: molecules/m2/sec
-       description: lnd import to med - MEGAN voc emission fluxes from lnd (1->20)
+       description: land export - MEGAN voc emission fluxes from land (1->20)
      #
      - standard_name: Sl_anidf
        canonical_units: 1
-       description: lnd import to med
+       description: land export
      #
      - standard_name: Sl_anidr
        canonical_units: 1
-       description: lnd import to med
+       description: land export
      #
      - standard_name: Sl_avsdf
        canonical_units: 1
-       description: lnd import to med
+       description: land export
      #
      - standard_name: Sl_avsdr
        canonical_units: 1
-       description: lnd import to med
+       description: land export
      #
      - standard_name: Sl_ddvel
        canonical_units: cm/sec
-       description: lnd import to med - dry deposition velocities from (1->80)
+       description: land export - dry deposition velocities from (1->80)
      #
      - standard_name: Sl_fv
        canonical_units: m s-1
-       description: lnd import to med
+       description: land export
      #
      - standard_name: Sl_fztop
        canonical_units: m
-       description: lnd import to med
+       description: land export
      #
      - standard_name: Sl_lfrac
        canonical_units: 1
-       description: lnd import to med
+       description: land export
      #
      - standard_name: Sl_lfrin
        canonical_units: 1
-       description: lnd import to med
+       description: land export
      #
      - standard_name: Sl_qref
        canonical_units: kg kg-1
-       description: lnd import to med
+       description: land export
      #
      - standard_name: Sl_qref_wiso
        canonical_units: kg kg-1
-       description: lnd import to med
+       description: land export
      #
      - standard_name: Sl_ram1
        canonical_units: s/m
-       description: lnd import to med
+       description: land export
      #
      - standard_name: Sl_snowh
        canonical_units: m
-       description: lnd import to med
+       description: land export
      #
      - standard_name: Sl_snowh_wiso
        canonical_units: m
-       description: lnd import to med
+       description: land export
      #
      - standard_name: Sl_soilw
        canonical_units: m3/m3
-       description: lnd import to med
+       description: land export
      #
      - standard_name: Sl_t
        canonical_units: K
-       description: lnd import to med
-     #
-     - standard_name: Flrl_irrig
-       canonical_units: kg m-2 s-1
-       description: lnd export to river
-     #
-     - standard_name: Flrl_rofdto
-       canonical_units: kg m-2 s-1
-       description: lnd export to river
-     #
-     - standard_name: Flrl_rofgwl
-       canonical_units: kg m-2 s-1
-       description: lnd export to river
-     #
-     - standard_name: Flrl_rofi
-       canonical_units: kg m-2 s-1
-       description: lnd export to river
-     #
-     - standard_name: Flrl_rofsub
-       canonical_units: kg m-2 s-1
-       description: lnd export to river
-     #
-     - standard_name: Flrl_rofsur
-       canonical_units: kg m-2 s-1
-       description: lnd export to river
+       description: land export
      #
      - standard_name: Sl_topo_elev
        canonical_units: m
-       description: lnd import to med with elevation classes (1->glc_nec)
-     #
-     - standard_name: Sl_tsrf_elev
-       canonical_units: deg C
-       description: lnd import to med with elevation classes (1->glc_nec)
-     #
-     - standard_name: Flgl_qice_elev
-       canonical_units: kg m-2 s-1
-       description: lnd import to med in elevation classes (1->glc_nec)
-     #
-     #-----------------------------------
-     # section: lnd export from med (computed in med)
-     #-----------------------------------
+       description: land export to mediator in elevation classes (1->glc_nec)
      #
      - standard_name: Sl_topo
        canonical_units: m
-       description: lnd export from med with no elevation classes (computed in med)
+       description: mediator export to glc - no levation classes
+     #
+     - standard_name: Sl_tsrf_elev
+       canonical_units: deg C
+       description: land export to mediator in elevation classes (1->glc_nec)
      #
      - standard_name: Sl_tsrf
        canonical_units: deg C
-       description: lnd export from med with no elevation classes (computed in med)
+       description: mediator export to gcl with no elevation classes
      #
      - standard_name: Sl_tref
        canonical_units: K
-       description: lnd export from med with no elevation classes (computed in med)
+       description: mediator export to glc - no levation classes
      #
      - standard_name: Sl_u10
        canonical_units: m
-       description: lnd import to med with no elevation classes (computed in med)
-     #
-     - standard_name: Flgl_qice
-       canonical_units: kg m-2 s-1
-       description: lnd export to med no elevation classes (computed in med)
+       description: land export
      #
      #-----------------------------------
-     # section: atm import to med
+     # section: atmosphere export
      #-----------------------------------
      #
      - standard_name: Faxa_nhx
        canonical_units: kg m-2 s-1
-       description: atm import to med
+       description: atmosphere export
      #
      - standard_name: Faxa_noy
        canonical_units: kg m-2 s-1
-       description: atm import to med
+       description: atmosphere export
      #
      - standard_name: Faxa_bcph
        canonical_units: kg m-2 s-1
-       description: atm import to med
+       description: atmosphere export
      #
      - standard_name: Faxa_ocph
        canonical_units: kg m-2 s-1
-       description: atm import to med
+       description: atmosphere export
      #
      - standard_name: Faxa_dstdry
        canonical_units: kg m-2 s-1
-       description: atm import to med
+       description: atmosphere export
      #
      - standard_name: Faxa_dstwet
        canonical_units: kg m-2 s-1
-       description: atm import to med
+       description: atmosphere export
      #
      - standard_name: Faxa_swdn
        alias: mean_down_sw_flx
        canonical_units: W m-2
-       description: atm import to med
+       description: atmosphere export
          mean downward SW heat flux
      #
      - standard_name: Faxa_lwdn
        alias: mean_down_lw_flx
        canonical_units: W m-2
-       description: atm import to med
+       description: atmosphere export
          mean downward SW heat flux
      #
      - standard_name: Faxa_ndep
        canonical_units: kg(N)/m2/sec
-       description: atm import to med - currently nhx and noy
+       description: atmosphere export to land and ocean - currently nhx and noy
      #
      - standard_name: Faxa_prec_wiso
        canonical_units: kg m-2 s-1
-       description: atm import to med
+       description: atmosphere export
      #
      - standard_name: Faxa_rain
        alias: mean_prec_rate
        canonical_units: kg m-2 s-1
-       description: atm import to med
+       description: atmosphere export
      #
      - standard_name: Faxa_rain_wiso
        alias: mean_prec_rate_wiso
        canonical_units: kg m-2 s-1
-       description: atm import to med
+       description: atmosphere export
      #
      - standard_name: Faxa_rainc
        canonical_units: kg m-2 s-1
-       description: atm import to med
+       description: atmosphere export
      #
      - standard_name: Faxa_rainc_wiso
        canonical_units: kg m-2 s-1
-       description: atm import to med
+       description: atmosphere export
      #
      - standard_name: Faxa_rainl
        canonical_units: kg m-2 s-1
-       description: atm import to med
+       description: atmosphere export
      #
      - standard_name: Faxa_rainl_wiso
        canonical_units: kg m-2 s-1
-       description: atm import to med
+       description: atmosphere export
      #
      - standard_name: Faxa_snow
        alias: mean_fprec_rate
        canonical_units: kg m-2 s-1
-       description: atm import to med
+       description: atmosphere export
      #
      - standard_name: Faxa_snow_wiso
        canonical_units: kg m-2 s-1
-       description: atm import to med
+       description: atmosphere export
      #
      - standard_name: Faxa_snowc
        canonical_units: kg m-2 s-1
-       description: atm import to med
+       description: atmosphere export
      #
      - standard_name: Faxa_snowc_wiso
        canonical_units: kg m-2 s-1
-       description: atm import to med
+       description: atmosphere export
      #
      - standard_name: Faxa_snowl
        canonical_units: kg m-2 s-1
-       description: atm import to med
+       description: atmosphere export
      #
      - standard_name: Faxa_snowl_wiso
        canonical_units: kg m-2 s-1
-       description: atm import to med
+       description: atmosphere export
      #
      - standard_name: Faxa_swnet
        canonical_units: W m-2
-       description: atm import to med
+       description: atmosphere export
      #
      - standard_name: Faxa_lwnet
        canonical_units: W m-2
-       description: atm import to med
+       description: atmosphere export
      #
      - standard_name: Faxa_swndf
        alias: mean_down_sw_ir_dif_flx
        canonical_units: W m-2
-       description: atm import to med - mean surface downward nir diffuse flux
+       description: atmosphere export - mean surface downward nir diffuse flux
      #
      - standard_name: Faxa_swndr
        alias: mean_down_sw_ir_dir_flx
        canonical_units: W m-2
-       description: atm import to med - mean surface downward nir direct flux
+       description: atmosphere export - mean surface downward nir direct flux
      #
      - standard_name: Faxa_swvdf
        alias: mean_down_sw_vis_dif_flx
        canonical_units: W m-2
-       description: atm import to med - mean surface downward uv+vis diffuse flux
+       description: atmosphere export - mean surface downward uv+vis diffuse flux
      #
      - standard_name: Faxa_swvdr
        alias: mean_down_sw_vis_dir_flx
        canonical_units: W m-2
-       description: atm import to med - mean surface downward uv+visvdirect flux
+       description: atmosphere export - mean surface downward uv+visvdirect flux
      #
      - standard_name: Sa_co2diag
        canonical_units: 1e-6 mol/mol
-       description: atm import to med - diagnostic CO2 at the lowest model level
+       description: atmosphere export - diagnostic CO2 at the lowest model level
      #
      - standard_name: Sa_co2prog
        canonical_units: 1e-6 mol/mol
-       description: atm import to med - prognostic CO2 at the lowest model level
+       description: atmosphere export - prognostic CO2 at the lowest model level
      #
      - standard_name: Sa_o3
        canonical_units: mol/mol
-       description: atm import to med - O3 in the lowest model layer (prognosed or prescribed)
+       description: atmosphere export - O3 in the lowest model layer (prognosed or prescribed)
      #
      - standard_name: Sa_lightning
        canonical_units: /min
-       description: atm import to med - lightning flash freqency
+       description: atmosphere export - lightning flash freqency
      #
      - standard_name: Sa_topo
        alias: inst_surface_height
        canonical_units: m
-       description: atm import to med - topographic height
+       description: atmosphere export - topographic height
      #
      - standard_name: Sa_dens
        alias: air_density_height_lowest
        canonical_units: kg m-3
-       description: atm import to med - density at the lowest model layer
+       description: atmosphere export - density at the lowest model layer
      #
      - standard_name: Sa_pbot
        alias: inst_pres_height_lowest
        canonical_units: Pa
-       description: atm import to med - pressure at lowest model layer
+       description: atmosphere export - pressure at lowest model layer
      #
      - standard_name: Sa_pslv
        alias: inst_pres_height_surface
        canonical_units: Pa
-       description: atm import to med
+       description: atmosphere export
      #
      - standard_name: Sa_ptem
        canonical_units: K
-       description: atm import to med - bottom layer potential temperature
+       description: atmosphere export - bottom layer potential temperature
      #
      - standard_name: Sa_shum
        alias: inst_spec_humid_height_lowest
        canonical_units: kg kg-1
-       description: atm import to med - bottom layer specific humidiaty
+       description: atmosphere export - bottom layer specific humidity
      #
      - standard_name: Sa_shum_wiso
        alias: inst_spec_humid_height_lowest_wiso
        canonical_units: kg kg-1
-       description: atm import to med - bottom layer specific humidity 16O, 18O, HDO
+       description: atmosphere export - bottom layer specific humidity 16O, 18O, HDO
      #
      - standard_name: Sa_tbot
        alias: inst_temp_height_lowest
        canonical_units: K
-       description: atm import to med - bottom layer temperature
+       description: atmosphere export - bottom layer temperature
      #
      - standard_name: Sa_tskn
        alias: inst_temp_skin_temperature
        canonical_units: K
-       description: atm import to med - sea surface skin temperature
+       description: atmosphere export - sea surface skin temperature
      #
      - standard_name: Sa_u
        alias: inst_zonal_wind_height_lowest
        canonical_units: m s-1
-       description: atm import to med - bottom layer zonal wind
+       description: atmosphere export - bottom layer zonal wind
      #
      - standard_name: Sa_v
        alias: inst_merid_wind_height_lowest
        canonical_units: m s-1
-       description: atm import to med - bottom layer meridional wind
-     #
-     - standard_name: Sa_u10m
-       canonical_units: m s-1
-       description: atm import to med - 10m zonal wind
-     #
-     - standard_name: Sa_v10m
-       canonical_units: m s-1
-       description: atm import to med- 10m meridional wind
+       description: atmosphere export - bottom layer meridional wind
      #
      - standard_name: Sa_wspd
        alias: inst_wind_speed_height_lowest
        canonical_units: m s-1
-       description: atm import to med - bottom layer wind speed
+       description: atmosphere export - bottom layer wind speed
      #
      - standard_name: Sa_z
        alias: inst_height_lowest
        canonical_units: m
-       description: atm import to med - bottom layer height
+       description: atmosphere export - bottom layer height
      #
      - standard_name: Faxa_taux
        alias: mean_zonal_moment_flx_atm
        canonical_units: N m-2
-       description: atm import to med - zonal component of momentum flux
+       description: atmosphere export - zonal component of momentum flux
      #
      - standard_name: Faxa_tauy
        alias: mean_merid_moment_flx_atm
        canonical_units: N m-2
-       description: atm import to med - meridional component of momentum flux
+       description: atmosphere export - meridional component of momentum flux
      #
      - standard_name: Faxa_lat
        alias: mean_laten_heat_flx_atm
        canonical_units: W m-2
-       description: atm import to med
+       description: atmosphere export
      #
      - standard_name: Faxa_sen
        alias: mean_sensi_heat_flx_atm
        canonical_units: W m-2
-       description: atm import to med
+       description: atmosphere export
      #
      #-----------------------------------
-     # section: atm export from med (computed in med)
+     # section: atmosphere import
      #-----------------------------------
      #
      - standard_name: Faxx_evap
        canonical_units: kg m-2 s-1
-       description: atm export from meditor - merged water evaporation flux
+       description: to atm merged water evaporation flux
      #
      - standard_name: Faxx_evap_wiso
        canonical_units: kg m-2 s-1
-       description: atm export from med - merged water evaporation flux for 16O, 18O and HDO
+       description: to atm merged water evaporation flux for 16O, 18O and HDO
      #
      - standard_name: Faxx_lat
        alias: mean_laten_heat_flx
        canonical_units: W m-2
-       description: atm export from med -  merged latent heat flux
+       description: to to atm merged latent heat flux
      #
      - standard_name: Faxx_lwup
        canonical_units: W m-2
-       description: atm export from med -  merged outgoing longwave radiation
+       description: to atm merged outgoing longwave radiation
      #
      - standard_name: Faxx_sen
        alias: mean_sensi_heat_flx
        canonical_units: W m-2
-       description: atm export from med -  merged sensible heat flux
+       description: to atm merged sensible heat flux
      #
      - standard_name: Faxx_taux
        alias: mean_zonal_moment_flx
        canonical_units: N m-2
-       description: atm export from med -  merged zonal surface stress
+       description: to atm merged zonal surface stress
      #
      - standard_name: Faxx_tauy
        alias: mean_merid_moment_flx
        canonical_units: N m-2
-       description: atm export from med -  merged meridional surface stress
+       description: to atm merged meridional surface stress
      #
      - standard_name: Sx_anidf
        canonical_units: 1
-       description: atm export from med -  merged surface diffuse albedo (near-infrared radiation)
+       description: atmosphere import
+       description: to atm merged surface diffuse albedo (near-infrared radiation)
      #
      - standard_name: Sx_anidr
        canonical_units: 1
-       description: atm export from med -  merged direct surface albedo (near-infrared radiation)
+       description: to atm merged direct surface albedo (near-infrared radiation)
      #
      - standard_name: Sx_avsdf
        canonical_units: 1
-       description: atm export from med -  merged surface diffuse albedo (visible radation)
+       description: to atm merged surface diffuse albedo (visible radation)
      #
      - standard_name: Sx_avsdr
        canonical_units: 1
-       description: atm export from med -  merged direct surface albedo (visible radiation)
+       description: to atm merged direct surface albedo (visible radiation)
      #
      - standard_name: Sx_qref
        canonical_units: kg kg-1
-       description: atm export from med
+       description: atmosphere import
      #
      - standard_name: Sx_qref_wiso
        canonical_units: kg kg-1
-       description: atm export from med
+       description: atmosphere import
      #
      - standard_name: Sx_t
        alias: surface_temperature
        canonical_units: K
-       description: atm export from med
+       description: atmosphere import
      #
      - standard_name: Sx_tref
        canonical_units: K
-       description: atm export from med
+       description: atmosphere import
      #
      - standard_name: Sx_u10
        canonical_units: m
-       description: atm export from med
+       description: atmosphere import
      #
      - standard_name: So_ugustOut
        canonical_units: m/s
-       description: atm export from med
+       description: atmosphere import
      #
      - standard_name: So_u10withGust
        canonical_units: m/s
-       description: atm export from med
+       description: atmosphere import
      #
      - standard_name: So_u10res
        canonical_units: m/s
-       description: atm export from med
+       description: atmosphere import
      #
      #-----------------------------------
-     # section: glc import to med
-     #-----------------------------------
-     #
+     # section: land-ice export
      # Note that the fields sent from glc->med do NOT have elevation classes,
      # but the fields from med->lnd are broken into multiple elevation classes
-     #
-     - standard_name: Fgrg_rofi
-       canonical_units: kg m-2 s-1
-       description: glc import tomed - glacier frozen_runoff_flux_to_ocean
-     #
-     - standard_name: Fgrg_rofi_wiso
-       canonical_units: kg m-2 s-1
-       description: glc import to med - glacier_frozen_runoff_flux_to_ocean for 16O, 18O, HDO
-     #
-     - standard_name: Fgrg_rofl
-       canonical_units: kg m-2 s-1
-       description: glc import to med - glacier liquid runoff flux to ocean
-     #
-     - standard_name: Fgrg_rofl_wiso
-       canonical_units: kg m-2 s-1
-       description: glc import to med - glacier_frozen_runoff_flux_to_ocean for 16O, 18O, HDO
+     #-----------------------------------
      #
      - standard_name: Figg_rofi
        canonical_units: kg m-2 s-1
-       description: glc import to med - glc frozen runoff_iceberg flux to ice
+       description: land-ice export - glc frozen runoff_iceberg flux to ice
      #
      - standard_name: Figg_rofi_wiso
        canonical_units: kg m-2 s-1
-       description: glc import to med - glc frozen runoff_iceberg flux to ice for 16O, 18O, HDO
+       description: land-ice export - glc frozen runoff_iceberg flux to ice for 16O, 18O, HDO
      #
      - standard_name: Flgg_hflx
        canonical_units: W m-2
-       description: glc import to med to med (no elevation classes)
-         Downward heat flux from glacier interior, from med, elev class 0
-     #
-     - standard_name: Sg_area
-       canonical_units: area internal to the CISM grid in radians**2
-       description: glc import to med to med (no elevation classes)
-     #
-     - standard_name: Sg_ice_covered
-       canonical_units: 1
-       description: glc import to med (no elevation classes)
-     #
-     - standard_name: Sg_icemask
-       canonical_units: 1
-       description: glc import to med
-     #
-     - standard_name: Sg_icemask_coupled_fluxes
-       canonical_units: 1
-       description: glc import to med
-     #
-     - standard_name: Sg_topo
-       canonical_units: m
-       description: glc import to med (no elevation classes)
-     #
-     #-----------------------------------
-     # section: glc export from med (computed in med)
-     #-----------------------------------
+       description: land-ice export to mediator (no elevation classes)
+         Downward heat flux from glacier interior, from mediator, elev class 0
      #
      - standard_name: Flgg_hflx_elev
        canonical_units: W m-2
-       description: glc export from med (elevation classes 1->glc_nec)
-         Downward heat flux from glacier interior, from med, elev class 1->glc_nec
+       description: mediator land-ice export to lnd (elevation classes 1->glc_nec)
+         Downward heat flux from glacier interior, from mediator, elev class 1->glc_nec
+     #
+     - standard_name: Sg_area
+       canonical_units: area internal to the CISM grid in radians**2
+       description: land-ice export to mediator (no elevation classes)
+     #
+     - standard_name: Sg_ice_covered
+       canonical_units: 1
+       description: land-ice export to mediator (no elevation classes)
      #
      - standard_name: Sg_ice_covered_elev
        canonical_units: 1
-       description: glc export from med (elevation classes 1->glc_nec)
+       description: mediator land-ice export to lnd (elevation classes 1->glc_nec)
+     #
+     - standard_name: Sg_icemask
+       canonical_units: 1
+       description: land-ice export
+     #
+     - standard_name: Sg_icemask_coupled_fluxes
+       canonical_units: 1
+       description: land-ice export
+     #
+     - standard_name: Sg_topo
+       canonical_units: m
+       description: land-ice export to mediator (no elevation classes)
      #
      - standard_name: Sg_topo_elev
        canonical_units: m
-       description: glc export from med (elevation classes 1->glc_nec)
+       description: mediator land-ice export to lnd (elevation classes 1->glc_nec)
+     #
+     - standard_name: Fogg_rofi
+       canonical_units: kg m-2 s-1
+       description: land-ice export - glacier_frozen_runoff_flux_to_ocean
+     #
+     - standard_name: Fogg_rofi_wiso
+       canonical_units: kg m-2 s-1
+       description: land-ice export - glacier_frozen_runoff_flux_to_ocean for 16O, 18O, HDO
+     #
+     - standard_name: Fogg_rofl
+       canonical_units: kg m-2 s-1
+       description: land-ice export - glacier liquid runoff flux to ocean
+     #
+     - standard_name: Fogg_rofl_wiso
+       canonical_units: kg m-2 s-1
+       description: land-ice export - glacier_frozen_runoff_flux_to_ocean for 16O, 18O, HDO
      #
      #-----------------------------------
-     # section: ice import to med
+     # section: sea-ice export
      #-----------------------------------
      #
      - standard_name: Faii_evap
        alias: mean_evap_rate_atm_into_ice
        canonical_units: kg m-2 s-1
-       description: ice import to med
+       description: sea-ice export
      #
      - standard_name: Faii_evap_wiso
        canonical_units: kg m-2 s-1
-       description: ice import to med for 16O, 18O, HDO
+       description: sea-ice export for 16O, 18O, HDO
      #
      - standard_name: Faii_lat
        alias: mean_laten_heat_flx_atm_into_ice
        canonical_units: W m-2
-       description: ice import to med - atm/ice latent heat flux
+       description: sea-ice export to atm - atm/ice latent heat flux
      #
      - standard_name: Faii_sen
        alias: mean_sensi_heat_flx_atm_into_ice
        canonical_units: W m-2
-       description: ice import to med - atm/ice sensible heat flux
+       description: sea-ice export to atm - atm/ice sensible heat flux
      #
      - standard_name: Faii_lwup
        alias: mean_up_lw_flx_ice
        canonical_units: W m-2
-       description: ice import to med -outgoing logwave radiation
+       description: sea-ice export -outgoing logwave radiation
      #
      - standard_name: Faii_swnet
        canonical_units: W m-2
-       description: ice import to med to atm
+       description: sea-ice export to atm
      #
      - standard_name: Faii_taux
        alias: stress_on_air_ice_zonal
        canonical_units: N m-2
-       description: ice import to med - air ice zonal stress
+       description: sea-ice export to atm - air ice zonal stress
      #
      - standard_name: Faii_tauy
        alias: stress_on_air_ice_merid
        canonical_units: N m-2
-       description: ice import to med - air ice meridional stress
+       description: sea-ice export - air ice meridional stress
      #
      - standard_name: Fioi_bcphi
        canonical_units: kg m-2 s-1
-       description: ice import to med to ocean - hydrophilic black carbon flux to ocean
+       description: sea-ice export to ocean - hydrophilic black carbon flux to ocean
      #
      - standard_name: Fioi_bcpho
        canonical_units: kg m-2 s-1
-       description: ice import to med to ocean - hydrophobic black carbon flux to ocean
+       description: sea-ice export to ocean - hydrophobic black carbon flux to ocean
      #
      - standard_name: Fioi_flxdst
        canonical_units: kg m-2 s-1
-       description: ice import to med to ocean - dust aerosol flux to ocean
+       description: sea-ice export to ocean - dust aerosol flux to ocean
      #
      - standard_name: Fioi_melth
        alias: net_heat_flx_to_ocn
        canonical_units: W m-2
-       description: ice import to med to ocean - net heat flux to ocean
+       description: sea-ice export to ocean - net heat flux to ocean
      #
      - standard_name: Fioi_melth_wiso
        canonical_units: kg m-2 s-1
-       description: ice import to med to ocean - isotope head flux to ocean for 16O, 18O, HDO
+       description: sea-ice export to ocean - isotope head flux to ocean for 16O, 18O, HDO
      #
      - standard_name: Fioi_melth_HDO
        canonical_units: kg m-2 s-1
-       description: ice import to med to ocean - isotope head flux to ocean
+       description: sea-ice export to ocean - isotope head flux to ocean
      #
      - standard_name: Fioi_meltw
        alias: mean_fresh_water_to_ocean_rate
        canonical_units: kg m-2 s-1
-       description: ice import to med to ocean - fresh water to ocean (h2o flux from melting)
+       description: sea-ice export to ocean - fresh water to ocean (h2o flux from melting)
      #
      - standard_name: Fioi_meltw_wiso
        alias: mean_fresh_water_to_ocean_rate_wiso
        canonical_units: kg m-2 s-1
-       description: ice import to med to ocean - fresh water to ocean (h2o flux from melting) for 16O, 18O, HDO
+       description: sea-ice export to ocean - fresh water to ocean (h2o flux from melting) for 16O, 18O, HDO
      #
      - standard_name: Fioi_salt
        alias: mean_salt_rate
        canonical_units: kg m-2 s-1
-       description: ice import to med - salt to ocean (salt flux from melting)
+       description: sea-ice export to ocean - salt to ocean (salt flux from melting)
      #
      - standard_name: Fioi_swpen
        alias: mean_sw_pen_to_ocn
        canonical_units: W m-2
-       description: ice import to med - flux of shortwave through ice to ocean
+       description: sea-ice export to ocean - flux of shortwave through ice to ocean
      #
      - standard_name: Fioi_swpen_vdr
        alias: mean_sw_pen_to_ocn_vis_dir_flx
        canonical_units: W m-2
-       description: ice import to med - flux of vis dir shortwave through ice to ocean
+       description: sea-ice export to ocean - flux of vis dir shortwave through ice to ocean
      #
      - standard_name: Fioi_swpen_vdf
        alias: mean_sw_pen_to_ocn_vis_dif_flx
        canonical_units: W m-2
-       description: ice import to med - flux of vif dir shortwave through ice to ocean
+       description: sea-ice export to ocean - flux of vif dir shortwave through ice to ocean
      #
      - standard_name: Fioi_swpen_idr
        alias: mean_sw_pen_to_ocn_ir_dir_flx
        canonical_units: W m-2
-       description: ice import to med - flux of ir dir shortwave through ice to ocean
+       description: sea-ice export to ocean - flux of ir dir shortwave through ice to ocean
      #
      - standard_name: Fioi_swpen_idf
        alias: mean_sw_pen_to_ocn_ir_dif_flx
        canonical_units: W m-2
-       description: ice import to med - flux of ir dif shortwave through ice to ocean
+       description: sea-ice export to ocean - flux of ir dif shortwave through ice to ocean
      #
      - standard_name: Fioi_taux
        alias: stress_on_ocn_ice_zonal
        canonical_units: N m-2
-       description: ice import to med - ice ocean zonal stress
+       description: sea-ice export to ocean - ice ocean zonal stress
      #
      - standard_name: Fioi_tauy
        alias: stress_on_ocn_ice_merid
        canonical_units: N m-2
-       description: ice import to med - ice ocean meridional stress
+       description: sea-ice export to ocean - ice ocean meridional stress
      #
      - standard_name: Si_anidf
        alias: inst_ice_ir_dif_albedo
        canonical_units: 1
-       description: ice import to med
+       description: sea-ice export to atm
      #
      - standard_name: Si_anidr
        alias: inst_ice_ir_dir_albedo
        canonical_units: 1
-       description: ice import to med
+       description: sea-ice export to atm
      #
      - standard_name: Si_avsdf
        alias: inst_ice_vis_dif_albedo
        canonical_units: 1
-       description: ice import to med
+       description: sea-ice export to atm
      #
      - standard_name: Si_avsdr
        alias: inst_ice_vis_dir_albedo
        canonical_units: 1
-       description: ice import to med
+       description: sea-ice export to atm
      #
      - standard_name: Si_ifrac
        alias: ice_fraction
        canonical_units: 1
-       description: ice import to med - ice fraction (varies with time)
+       description: sea-ice export to atm
+         ice fraction (varies with time)
      #
      - standard_name: Si_ifrac_n
        alias: ice_fraction_n
        canonical_units: 1
-       description: ice import to med - ice fraction per category (varies with time)
+       description: sea-ice export - ice fraction per category (varies with time)
      #
      - standard_name: Si_imask
        alias: ice_mask
        canonical_units: 1
-       description: ice import to med - ice mask
+       description: sea-ice export - ice mask
      #
      - standard_name: Si_qref
        canonical_units: kg kg-1
-       description: ice import to med
+       description: sea-ice export to atm
      #
      - standard_name: Si_qref_wiso
        canonical_units: kg kg-1
-       description: ice import to med
+       description: sea-ice export to atm
      #
      - standard_name: Si_t
        alias: sea_ice_surface_temperature
        canonical_units: K
-       description: ice import to med
+       description: sea-ice export
      #
      - standard_name: Si_tref
        canonical_units: K
-       description: ice import to med
+       description: sea-ice export
      #
      - standard_name: Si_u10
        canonical_units: m
-       description: ice import to med
+       description: sea-ice export
      #
      - standard_name: Si_vice
        alias: mean_ice_volume
        canonical_units: m
-       description: ice import to med - volume of ice per unit area
+       description: sea-ice export
+         volume of ice per unit area
      #
      - standard_name: Si_snowh
        canonical_units: m
-       description: ice import to med - surface_snow_water_equivalent
+       description: sea-ice export - surface_snow_water_equivalent
      #
      - standard_name: Si_vsno
        alias: mean_snow_volume
        canonical_units: m
-       description: ice import to med - volume of snow per unit area
+       description: sea-ice export - volume of snow per unit area
      #
      - standard_name: Si_thick
        canonical_units: m
-       description: ice import to med - ice thickness
+       description: sea-ice export - ice thickness
      #
      - standard_name: Si_floediam
        canonical_units: m
-       description: ice import to med - ice floe diameter
+       description: sea-ice export - ice floe diameter
        #
      #-----------------------------------
-     # section: ocn import to med
+     # section: ocean export to mediator
      #-----------------------------------
      #
      - standard_name: Fioo_q
        alias: freezing_melting_potential
        canonical_units: W m-2
-       description: ocn import to med
+       description: ocean export
      #
      - standard_name: Faoo_fco2_ocn
        canonical_units: moles m-2 s-1
-       description: ocn import to med - surface flux of CO2 (downward positive)
-     #
-     - standard_name: Faoo_fdms_ocn
-       canonical_units: moles m-2 s-1
-       description: ocn import to med - surface flux of DMS (downward positive)
-     #
-     - standard_name: Faoo_fbrf_ocn
-       canonical_units: moles m-2 s-1
-       description: ocn import to med - surface flux of Bromoform (downward positive)
-     #
-     - standard_name: Faoo_fn2o_ocn
-       canonical_units: moles m-2 s-1
-       description: ocn import to med - surface flux of N2O (downward positive)
-     #
-     - standard_name: Faoo_fnh3_ocn
-       canonical_units: moles m-2 s-1
-       description: ocn import to med - surface flux of NH3 (downward positive)
+       description: ocean export
      #
      - standard_name: So_anidf
        canonical_units: 1
-       description: ocn import to med
+       description: ocean export
      #
      - standard_name: So_anidr
        canonical_units: 1
-       description: ocn import to med
+       description: ocean export
      #
      - standard_name: So_avsdf
        canonical_units: 1
-       description: ocn import to med
+       description: ocean export
      #
      - standard_name: So_avsdr
        canonical_units: 1
-       description: ocn import to med
+       description: ocean export
      #
      - standard_name: So_bldepth
        alias: mixed_layer_depth
        canonical_units: m
-       description: ocn import to med
+       description: ocean export
      #
      - standard_name: So_dhdx
        alias: sea_surface_slope_zonal
        canonical_units: m m-1
-       description: ocn import to med
+       description: ocean export
      #
      - standard_name: So_dhdy
        alias: sea_surface_slope_merid
        canonical_units: m m-1
-       description: ocn import to med
+       description: ocean export
      #
      - standard_name: So_duu10n
        canonical_units: m2 s-2
-       description: ocn import to med
+       description: ocean export
      #
      - standard_name: So_fswpen
        canonical_units: 1
-       description: ocn import to med
+       description: ocean export
      #
      - standard_name: So_ofrac
        canonical_units: 1
-       description: ocn import to med
+       description: ocean export
      #
      - standard_name: So_omask
        alias: ocean_mask
        canonical_units: 1
-       description: ocn import to med
+       description: ocean export
      #
      - standard_name: So_qref
        canonical_units: kg kg-1
-       description: ocn import to med
+       description: ocean export
      #
      - standard_name: So_qref_wiso
        canonical_units: kg kg-1
-       description: ocn import to med
+       description: ocean export
      #
      - standard_name: So_re
        canonical_units: 1
-       description: ocn import to med
+       description: ocean export
      #
      - standard_name: So_qref_wiso
        canonical_units: kg kg-1
-       description: ocn import to med
+       description: ocean export
      #
      - standard_name: So_roce_wiso
        canonical_units: unitless
-       description: ocn import to med
+       description: ocean export
      #
      - standard_name: So_s
        alias: s_surf
        canonical_units: g kg-1
-       description: ocn import to med
+       description: ocean export
      #
      - standard_name: So_s_depth
        alias: s_surf_depths
@@ -955,12 +857,12 @@
      #
      - standard_name: So_ssq
        canonical_units: kg kg-1
-       description: ocn import to med
+       description: ocean export
      #
      - standard_name: So_t
        alias: sea_surface_temperature
        canonical_units: K
-       description: ocn import to med
+       description: ocean export
      #
      - standard_name: So_t_depth
        alias: sea_surface_temperature_depths
@@ -969,254 +871,292 @@
      #
      - standard_name: So_tref
        canonical_units: K
-       description: ocn import to med
+       description: ocean export
      #
      - standard_name: So_u
        alias: ocn_current_zonal
        canonical_units: m s-1
-       description: ocn import to med
+       description: ocean export
      #
      - standard_name: So_u10
        canonical_units: m
-       description: ocn import to med
+       description: ocean export
      #
      - standard_name: So_ustar
        canonical_units: m s-1
-       description: ocn import to med
+       description: ocean export
      #
      - standard_name: So_v
        alias: ocn_current_merid
        canonical_units: m s-1
-       description: ocn import to med
+       description: ocean export
      #
      #-----------------------------------
-     # section: ocn export from med (computed in med)
+     # section: river export
      #-----------------------------------
      #
-     - standard_name: Foxx_hrain
-       alias: heat_content_lprec
-       canonical_units: W m-2
-       description: med export to ocn heat content of rain
-     #
-     - standard_name: Foxx_hsnow
-       alias: heat_content_fprec
-       canonical_units: W m-2
-       description: med export to ocn heat content of snow
-     #
-     - standard_name: Foxx_hevap
-       alias: heat_content_evap
-       canonical_units: W m-2
-       description: med export to ocn heat content of evaporation
-     #
-     - standard_name: Foxx_hcond
-       alias: heat_content_cond
-       canonical_units: W m-2
-       description: med export to ocn heat content of condensation
-     #
-     - standard_name: Foxx_hrofl
-       alias: heat_content_rofl
-       canonical_units: W m-2
-       description: med export to ocn heat content of liquid runoff
-     #
-     - standard_name: Foxx_hrofi
-       alias: heat_content_rofi
-       canonical_units: W m-2
-       description: med export to ocn heat content of ice runoff
-     #
-     - standard_name: Foxx_hrofl_glc
-       alias: heat_content_rofl_glc
-       canonical_units: W m-2
-       description: med export to ocn heat content of liquid glc runoff
-     #
-     - standard_name: Foxx_hrofi_glc
-       alias: heat_content_rofi_glc
-       canonical_units: W m-2
-       description: med export to ocn heat content of ice glc runoff
-     #
-     - standard_name: Foxx_evap
-       alias: mean_evap_rate
+     - standard_name: Firr_rofi
        canonical_units: kg m-2 s-1
-       description: med export to ocn - specific humidity flux
+       description: river export - water flux into sea ice due to runoff (frozen)
      #
-     - standard_name: Foxx_evap_wiso
-       alias: mean_evap_rate_wiso
+     - standard_name: Firr_rofi_wiso
        canonical_units: kg m-2 s-1
-       description: med export to ocn - specific humidity flux 16O, 18O, HDO
+       description: river export - water flux into sea ice due to runoff (frozen) for 16O, 18O, HDO
      #
-     - standard_name: Foxx_lat
-       canonical_units: W m-2
-       description: med export to ocn - latent heat flux into ocean
-     #
-     - standard_name: Foxx_lat_wiso
-       canonical_units: W m-2
-       description: med export to ocn - latent heat flux into ocean for 16O, 18O, HDO
-     #
-     - standard_name: Foxx_lat
-       canonical_units: W m-2
-       description: med export to ocn - latent heat flux into ocean for HDO
-     #
-     - standard_name: Foxx_sen
-       alias: mean_sensi_heat_flx
-       canonical_units: W m-2
-       description: med export to ocn - sensible heat flux into ocean
-     #
-     - standard_name: Foxx_lwup
-       canonical_units: W m-2
-       description: med export to ocn - surface upward longwave heat flux
-     #
-     - standard_name: Foxx_lwnet
-       alias: mean_net_lw_flx
-       canonical_units: W m-2
-       description: med export to ocn - mean NET long wave radiation flux to ocean
-     #
-     - standard_name: mean_runoff_rate
+     - standard_name: Fixx_rofi
        canonical_units: kg m-2 s-1
-       description: med export to ocn - total runoff to ocean
+       description: frozen runoff to ice from river and land-ice
      #
-     - standard_name: mean_runoff_heat_flux
+     - standard_name: Fixx_rofi_wiso
        canonical_units: kg m-2 s-1
-       description: med export to ocn - heat content of runoff
-     #
-     - standard_name: mean_calving_rate
-       canonical_units: kg m-2 s-1
-       description: med export to ocn - total calving to ocean
-     #
-     - standard_name: mean_calving_heat_flux
-       canonical_units: kg m-2 s-1
-       description: med export to ocn - heat content of calving
-     #
-     - standard_name: Foxx_rofi
-       canonical_units: kg m-2 s-1
-       description: med export to ocn - water flux due to runoff (frozen)
-     #
-     - standard_name: Foxx_rofi_wiso
-       canonical_units: kg m-2 s-1
-       description: med export to ocn - water flux due to runoff (frozen) for 16O, 18O, HDO
-     #
-     - standard_name: Foxx_rofl
-       alias: mean_runoff_rate
-       canonical_units: kg m-2 s-1
-       description: med export to ocn - water flux due to runoff (liquid)
-     #
-     - standard_name: Foxx_rofl_wiso
-       canonical_units: kg m-2 s-1
-       description: med export to ocn - water flux due to runoff (liquid) for 16O, 18O, HDO
-     #
-     - standard_name: Foxx_swnet
-       alias: mean_net_sw_flx
-       canonical_units: W m-2
-       description: med export to ocn - net shortwave radiation to ocean
-     #
-     - standard_name: Foxx_swnet_vdr
-       alias: mean_net_sw_vis_dir_flx
-       canonical_units: W m-2
-       description: med export to ocn - net shortwave visible direct radiation to ocean
-     #
-     - standard_name: Foxx_swnet_vdf
-       alias: mean_net_sw_vis_dif_flx
-       canonical_units: W m-2
-       description: med export to ocn - net shortwave visible diffuse radiation to ocean
-     #
-     - standard_name: Foxx_swnet_idr
-       alias: mean_net_sw_ir_dir_flx
-       canonical_units: W m-2
-       description: med export to ocn - net shortwave ir direct radiation to ocean
-     #
-     - standard_name: Foxx_swnet_idf
-       alias: mean_net_sw_ir_dif_flx
-       canonical_units: W m-2
-       description: med export to ocn - net shortwave ir diffuse radiation to ocean
-     #
-     - standard_name: Foxx_swnet_afracr
-       canonical_units: W m-2
-       description: med export to ocn - net shortwave radiation times atmosphere fraction
-     #
-     - standard_name: Foxx_taux
-       alias: mean_zonal_moment_flx
-       canonical_units: N m-2
-       description: med export to ocn - zonal surface stress
-     #
-     - standard_name: Foxx_tauy
-       alias: mean_merid_moment_flx
-       canonical_units: N m-2
-       description: med export to ocn - meridional surface stress
-     #
-     - standard_name: Fioi_swpen_ifrac_n
-       alias: mean_sw_pen_to_ocn_ifrac_n
-       canonical_units: W m-2
-       description: med export to ocn - net shortwave radiation penetrating into ice and ocean times ice fraction for thickness category 1
-     #
-     - standard_name: Sf_afrac
-       canonical_units: 1
-       description: med export to ocn - fractional atmosphere coverage wrt ocean
-     #
-     - standard_name: Sf_afracr
-       canonical_units: 1
-       description: med export to ocn - fractional atmosphere coverage used in radiation computations wrt ocean
+       description: frozen runoff to ice from river and land-ice for 16O, 18O, HDO
      #
      #-----------------------------------
-     # section: river import to med
+     # section: lnd export to glc
+     #-----------------------------------
+     #
+     - standard_name: Flgl_qice
+       canonical_units: kg m-2 s-1
+       description: mediator export to glc no elevation classes
+     #
+     - standard_name: Flgl_qice_elev
+       canonical_units: kg m-2 s-1
+       description: land export to mediator  in elevation classes (1->glc_nec)
+     #
+     #-----------------------------------
+     # section: lnd export to river
+     #-----------------------------------
+     #
+     - standard_name: Flrl_irrig
+       canonical_units: kg m-2 s-1
+       description: land export to river
+     #
+     - standard_name: Flrl_rofdto
+       canonical_units: kg m-2 s-1
+       description: land export to river
+     #
+     - standard_name: Flrl_rofgwl
+       canonical_units: kg m-2 s-1
+       description: land export to river
+     #
+     - standard_name: Flrl_rofi
+       canonical_units: kg m-2 s-1
+       description: land export to river
+     #
+     - standard_name: Flrl_rofsub
+       canonical_units: kg m-2 s-1
+       description: land export to river
+     #
+     - standard_name: Flrl_rofsur
+       canonical_units: kg m-2 s-1
+       description: land export to river
+     #
+     #-----------------------------------
+     # section: river export
      #-----------------------------------
      #
      - standard_name: Flrr_flood
        canonical_units: kg m-2 s-1
-       description: river import to med - water flux due to flooding
+       description: river export to land - water flux due to flooding
      #
      - standard_name: Flrr_flood_wiso
        canonical_units: kg m-2 s-1
-       description: river import to med - water flux due to flooding for 16O, 18O, HDO
+       description: river export to land - water flux due to flooding for 16O, 18O, HDO
      #
      - standard_name: Flrr_volr
        canonical_units: m
-       description: river import to med - river channel total water volume
+       description: river export to land - river channel total water volume
      #
      - standard_name: Flrr_volr_wiso
        canonical_units: m
-       description: river import to med - river channel total water volume from 16O, 18O, HDO
+       description: river export to land - river channel total water volume from 16O, 18O, HDO
      #
      - standard_name: Flrr_volrmch
        canonical_units: m
-       description: river import to med - river channel main channel water volume
+       description: river export to land - river channel main channel water volume
      #
      - standard_name: Flrr_volrmch_wiso
        canonical_units: m
-       description: river import to med - river channel main channel water volume from 16O, 18O, HDO
+       description: river export to land - river channel main channel water volume from 16O, 18O, HDO
      #
      - standard_name: Sr_tdepth
        canonical_units: m
-       description: river import to med - tributary channel water depth
+       description: river export to land - tributary channel water depth
      #
      - standard_name: Sr_tdepth_max
        canonical_units: m
-       description: river import to med - tributary channel bankfull depth
+       description: river export to land - tributary channel bankfull depth
      #
      - standard_name: Forr_rofi
        canonical_units: kg m-2 s-1
        description: river export to ocean - water flux due to runoff (frozen)
      #
-     - standard_name: Forr_rofi_glc
-       canonical_units: kg m-2 s-1
-       description: river export to ocean - water flux due to runoff originating from glc (frozen)
-     #
      - standard_name: Forr_rofi_wiso
        canonical_units: kg m-2 s-1
-       description: river import to med - water flux due to runoff (frozen) for 16O, 18O, HDO
+       description: river export to ocean - water flux due to runoff (frozen) for 16O, 18O, HDO
      #
      - standard_name: Forr_rofl
        canonical_units: kg m-2 s-1
-       description: river import to med - water flux due to runoff (liquid)
-     #
-     - standard_name: Forr_rofl_glc
-       canonical_units: kg m-2 s-1
-       description: river import to med - water flux due to runoff originating from glc (liquid)
+       description: river export to ocean - water flux due to runoff (liquid)
      #
      - standard_name: Forr_rofl_wiso
        canonical_units: kg m-2 s-1
-       description: river import to med - water flux due to runoff (frozen) for 16O, 18O, HDO
+       description: river export to ocean - water flux due to runoff (frozen) for 16O, 18O, HDO
      #
      #-----------------------------------
-     # section: wav import to med
+     # section: ocean import
      #-----------------------------------
+     #
+     - standard_name: Foxx_hrain
+       alias: heat_content_lprec
+       canonical_units: W m-2
+       description: to ocn heat content of rain
+     #
+     - standard_name: Foxx_hsnow
+       alias: heat_content_fprec
+       canonical_units: W m-2
+       description: to ocn heat content of snow
+     #
+     - standard_name: Foxx_hevap
+       alias: heat_content_evap
+       canonical_units: W m-2
+       description: to ocn heat content of evaporation
+     #
+     - standard_name: Foxx_hcond
+       alias: heat_content_cond
+       canonical_units: W m-2
+       description: to ocn heat content of condensation
+     #
+     - standard_name: Foxx_hrofl
+       alias: heat_content_rofl
+       canonical_units: W m-2
+       description: to ocn heat content of liquid runoff
+     #
+     - standard_name: Foxx_hrofi
+       alias: heat_content_rofi
+       canonical_units: W m-2
+       description: to ocn heat content of ice runoff
+     #
+     - standard_name: Foxx_evap
+       alias: mean_evap_rate
+       canonical_units: kg m-2 s-1
+       description: ocean import - specific humidity flux
+     #
+     - standard_name: Foxx_evap_wiso
+       alias: mean_evap_rate_wiso
+       canonical_units: kg m-2 s-1
+       description: ocean import - specific humidity flux 16O, 18O, HDO
+     #
+     - standard_name: Foxx_lat
+       canonical_units: W m-2
+       description: ocean import - latent heat flux into ocean
+     #
+     - standard_name: Foxx_lat_wiso
+       canonical_units: W m-2
+       description: ocean import - latent heat flux into ocean for 16O, 18O, HDO
+     #
+     - standard_name: Foxx_lat
+       canonical_units: W m-2
+       description: ocean import - latent heat flux into ocean for HDO
+     #
+     - standard_name: Foxx_sen
+       alias: mean_sensi_heat_flx
+       canonical_units: W m-2
+       description: ocean import - sensible heat flux into ocean
+     #
+     - standard_name: Foxx_lwup
+       canonical_units: W m-2
+       description: ocean import - surface upward longwave heat flux
+     #
+     - standard_name: Foxx_lwnet
+       alias: mean_net_lw_flx
+       canonical_units: W m-2
+       description: ocean import - mean NET long wave radiation flux to ocean
+     #
+     - standard_name: mean_runoff_rate
+       canonical_units: kg m-2 s-1
+       description: ocean import - total runoff to ocean
+     #
+     - standard_name: mean_runoff_heat_flux
+       canonical_units: kg m-2 s-1
+       description: ocean import - heat content of runoff
+     #
+     - standard_name: mean_calving_rate
+       canonical_units: kg m-2 s-1
+       description: ocean import - total calving to ocean
+     #
+     - standard_name: mean_calving_heat_flux
+       canonical_units: kg m-2 s-1
+       description: ocean import - heat content of calving
+     #
+     - standard_name: Foxx_rofi
+       canonical_units: kg m-2 s-1
+       description: ocean import - water flux due to runoff (frozen)
+     #
+     - standard_name: Foxx_rofi_wiso
+       canonical_units: kg m-2 s-1
+       description: ocean import - water flux due to runoff (frozen) for 16O, 18O, HDO
+     #
+     - standard_name: Foxx_rofl
+       alias: mean_runoff_rate
+       canonical_units: kg m-2 s-1
+       description: ocean import - water flux due to runoff (liquid)
+     #
+     - standard_name: Foxx_rofl_wiso
+       canonical_units: kg m-2 s-1
+       description: ocean import - water flux due to runoff (liquid) for 16O, 18O, HDO
+     #
+     - standard_name: Foxx_swnet
+       alias: mean_net_sw_flx
+       canonical_units: W m-2
+       description: ocean import - net shortwave radiation to ocean
+     #
+     - standard_name: Foxx_swnet_vdr
+       alias: mean_net_sw_vis_dir_flx
+       canonical_units: W m-2
+       description: ocean import - net shortwave visible direct radiation to ocean
+     #
+     - standard_name: Foxx_swnet_vdf
+       alias: mean_net_sw_vis_dif_flx
+       canonical_units: W m-2
+       description: ocean import - net shortwave visible diffuse radiation to ocean
+     #
+     - standard_name: Foxx_swnet_idr
+       alias: mean_net_sw_ir_dir_flx
+       canonical_units: W m-2
+       description: ocean import - net shortwave ir direct radiation to ocean
+     #
+     - standard_name: Foxx_swnet_idf
+       alias: mean_net_sw_ir_dif_flx
+       canonical_units: W m-2
+       description: ocean import - net shortwave ir diffuse radiation to ocean
+     #
+     - standard_name: Foxx_swnet_afracr
+       canonical_units: W m-2
+       description: ocean import - net shortwave radiation times atmosphere fraction
+     #
+     - standard_name: Foxx_taux
+       alias: mean_zonal_moment_flx
+       canonical_units: N m-2
+       description: ocean import - zonal surface stress
+     #
+     - standard_name: Foxx_tauy
+       alias: mean_merid_moment_flx
+       canonical_units: N m-2
+       description: ocean import - meridional surface stress
+     #
+     - standard_name: Fioi_swpen_ifrac_n
+       alias: mean_sw_pen_to_ocn_ifrac_n
+       canonical_units: W m-2
+       description: ocean import - net shortwave radiation penetrating into ice and ocean times ice fraction for thickness category 1
+     #
+     - standard_name: Sf_afrac
+       canonical_units: 1
+       description: ocean import - fractional atmosphere coverage wrt ocean
+     #
+     - standard_name: Sf_afracr
+       canonical_units: 1
+       description: ocean import - fractional atmosphere coverage used in radiation computations wrt ocean
      #
      - standard_name: Sw_hstokes
        canonical_units: m
@@ -1241,76 +1181,37 @@
      - standard_name: Sw_pstokes_y
        canonical_units: m/s
        description: Northward partitioned stokes drift components
+
      #
      - standard_name: Sw_elevation_spectrum
        alias: wave_elevation_spectrum
        canonical_units: m2/s
        description: wave elevation spectrum
+
      #
-     - standard_name: Sw_ustokes_avg
-       canonical_units: m/s
-       description: Daily averaged stokes drift u component (only needed for med history output)
+     #-----------------------------------
+     # section: wave import
+     #-----------------------------------
      #
-     - standard_name: Sw_vstokes_avg
-       canonical_units: m/s
-       description: Daily averaged stokes drift v component (only needed for med history output)
+     - standard_name: Fwxx_taux
+       alias: mean_zonal_moment_flx
+       canonical_units: N m-2
+       description: wave import - zonal surface stress
      #
-     - standard_name: Sw_hs_avg
-       canonical_units: m
-       description: Daily averaged significant wave hight (only needed for med history output)
+     - standard_name: Fwxx_tauy
+       alias: mean_merid_moment_flx
+       canonical_units: N m-2
+       description: wave import - meridional surface stress
+
+     #-----------------------------------
+     # mediator fields
+     #-----------------------------------
      #
-     - standard_name: Sw_phs0_avg
-       canonical_units: m
-       description: Daily averaged averaged wind sea swh (only needed for med history output)
+     - standard_name: cpl_scalars
+       canonical_units: unitless
      #
-     - standard_name: Sw_phs1_avg
-       canonical_units: m
-       description: Daily averaged swell swh (only needed for med history output)
+     - standard_name: frac
+       canonical_units: 1
      #
-     - standard_name: Sw_pdir0_avg
-       canonical_units: degrees
-       description: Daily averaged wind sea swh (only needed for med history output)
-     #
-     - standard_name: Sw_pdir1_avg
-       canonical_units: degrees
-       description: Daily averaged swell swh (only needed for med history output)
-     #
-     - standard_name: Sw_pTm10_avg
-       canonical_units: s
-       description: Daily averaged wind sea mean wave Tm1 period (only needed for med history output)
-     #
-     - standard_name: Sw_pTm11_avg
-       canonical_units: s
-       description: Daily average swell mean wave Tm1 period (only needed for med history output)
-     #
-     - standard_name: Sw_Tm1_avg
-       canonical_units: s
-       description: Daily averaged mean wave period of the first moment (only needed for med history output)
-     #
-     - standard_name: Sw_thm_avg
-       canonical_units: degrees
-       description: Daily averaged mean wave direction (only needed for med history output)
-     #
-     - standard_name: Sw_thp0_avg
-       canonical_units: degrees
-       description: Daily averaged peak wave direction (only needed for med history output)
-     #
-     - standard_name: Sw_fp0_avg
-       canonical_units: 1/s
-       description: Daily averaged peak wave frequency (only needed for med history output)
-     #
-     - standard_name: Sw_u_avg
-       canonical_units: m/s
-       description: Daily averaged surface wind zonal (only needed for med history output)
-     #
-     - standard_name: Sw_v_avg
-       canonical_units: m/s
-       description: Daily averaged surface wind meridional (only needed for med history output)
-     #
-     - standard_name: Sw_tusx_avg
-       canonical_units: m2/s
-       description: Daily averaged stokes zonal transport vector (only needed for med history output)
-     #
-     - standard_name: Sw_tusy_avg
-       canonical_units: m2/s
-       description: Daily averaged stokes meridional transport vector (only needed for med history output)
+     - standard_name: mask
+       canonical_units: 1

--- a/nuopc.runconfig
+++ b/nuopc.runconfig
@@ -36,22 +36,10 @@ PELAYOUT_attributes::
      cpl_pestride = 1
      cpl_rootpe = 0
      esmf_logging = ESMF_LOGKIND_NONE
-     esp_ntasks = 1
-     esp_nthreads = 1
-     esp_pestride = 1
-     esp_rootpe = 0
-     glc_ntasks = 1
-     glc_nthreads = 1
-     glc_pestride = 1
-     glc_rootpe = 0
      ice_ntasks = 24
      ice_nthreads = 1
      ice_pestride = 1
      ice_rootpe = 0
-     lnd_ntasks = 1
-     lnd_nthreads = 1
-     lnd_pestride = 1
-     lnd_rootpe = 0
      ninst = 1
      ocn_ntasks = 216
      ocn_nthreads = 1
@@ -64,10 +52,6 @@ PELAYOUT_attributes::
      rof_nthreads = 1
      rof_pestride = 1
      rof_rootpe = 0
-     wav_ntasks = 1
-     wav_nthreads = 1
-     wav_pestride = 1
-     wav_rootpe = 0
 ::
 
 component_list: MED ATM ICE OCN ROF
@@ -78,15 +62,15 @@ ALLCOMP_attributes::
      LND_model = slnd
      MED_model = cesm
      OCN_model = mom
-     Profiling = 0
      ROF_model = drof
+     WAV_model = swav
+     Profiling = 0
      ScalarFieldCount = 4
      ScalarFieldIdxGridNX = 1
      ScalarFieldIdxGridNY = 2
      ScalarFieldIdxNextSwCday = 3
      ScalarFieldIdxPrecipFactor = 0
      ScalarFieldName = cpl_scalars
-     WAV_model = swav
      brnch_retain_casename = .false.
      case_desc = UNSET
      case_name = access-om3
@@ -94,12 +78,9 @@ ALLCOMP_attributes::
      coldair_outbreak_mod = .false.
      data_assimilation_atm = .false.
      data_assimilation_cpl = .false.
-     data_assimilation_glc = .false.
      data_assimilation_ice = .false.
-     data_assimilation_lnd = .false.
      data_assimilation_ocn = .false.
      data_assimilation_rof = .false.
-     data_assimilation_wav = .false.
      flds_bgc_oi = .false.
      flds_co2a = .false.
      flds_co2b = .false.
@@ -107,6 +88,7 @@ ALLCOMP_attributes::
      flds_i2o_per_cat = .false.
      flds_r2l_stream_channel_depths = .false.
      flds_wiso = .false.
+     add_gusts = .false.
      flux_convergence = 0.01
      flux_max_iteration = 5
      glc_nec = 10
@@ -117,7 +99,6 @@ ALLCOMP_attributes::
      ice_ncat = 5
      mediator_present = true
      mesh_atm = ./INPUT/access-om2-1deg-nomask-ESMFmesh.nc
-     mesh_glc = UNSET
      mesh_ice = ./INPUT/access-om2-1deg-ESMFmesh.nc
      mesh_lnd = UNSET
      mesh_mask = ./INPUT/access-om2-1deg-ESMFmesh.nc
@@ -315,14 +296,6 @@ ICE_attributes::
      Verbosity = off
 ::
 
-GLC_attributes::
-     Verbosity = off
-::
-
-LND_attributes::
-     Verbosity = off
-::
-
 OCN_attributes::
      Verbosity = off
 ::
@@ -332,33 +305,28 @@ ROF_attributes::
      mesh_rof = ./INPUT/access-om2-1deg-nomask-ESMFmesh.nc
 ::
 
-WAV_attributes::
-     Verbosity = off
-     mesh_wav = UNSET
-::
-
 MED_modelio::
      diro = ./log
      logfile = med.log
      pio_async_interface = .false.
-     pio_netcdf_format = 64bit_offset
-     pio_numiotasks = -99
+     pio_netcdf_format = nothing
+     pio_numiotasks = 4
      pio_rearranger = 2
      pio_root = 1
-     pio_stride = 48
-     pio_typename = netcdf
+     pio_stride = 1
+     pio_typename = netcdf4p
 ::
 
 ATM_modelio::
      diro = ./log
      logfile = atm.log
      pio_async_interface = .false.
-     pio_netcdf_format = 64bit_offset
-     pio_numiotasks = -99
+     pio_netcdf_format = nothing
+     pio_numiotasks = 1
      pio_rearranger = 1
      pio_root = 1
-     pio_stride = 48
-     pio_typename = netcdf
+     pio_stride = 1
+     pio_typename = netcdf4p
 ::
 
 ICE_modelio::
@@ -368,8 +336,8 @@ ICE_modelio::
      pio_netcdf_format = nothing
      pio_numiotasks = 1
      pio_rearranger = 1
-     pio_root = 0
-     pio_stride = 48
+     pio_root = 1
+     pio_stride = 1
      pio_typename = netcdf4p
 ::
 
@@ -388,29 +356,16 @@ OCN_modelio::
 ROF_modelio::
      diro = ./log
      logfile = rof.log
-     pio_async_interface = .false. #not used
-     pio_netcdf_format = 64bit_offset #not used
-     pio_numiotasks = -99 #not used
-     pio_rearranger = 2 #not used
-     pio_root = 1 #not used
-     pio_stride = 48 #not used
-     pio_typename = netcdf #not used
-::
-
-WAV_modelio::
-     diro = ./log
-     logfile = wav.log
-     pio_async_interface = .false.
-     pio_netcdf_format = 64bit_offset
-     pio_numiotasks = -99
-     pio_rearranger = 2
-     pio_root = 1
-     pio_stride = 48
-     pio_typename = netcdf
+     pio_async_interface = .false. 
+     pio_netcdf_format = nothing 
+     pio_numiotasks = 1 
+     pio_rearranger = 2 
+     pio_root = 1 
+     pio_stride = 1
+     pio_typename = netcdf4p 
 ::
 
 DRV_modelio::
      diro = ./log
      logfile = drv.log
 ::
-

--- a/nuopc.runconfig
+++ b/nuopc.runconfig
@@ -137,7 +137,7 @@ ALLCOMP_attributes::
      start_type = startup
      tfreeze_option = linear_salt
      wav_coupling_to_cice = .false.
-     write_restart_at_endofrun = .false.
+     restart_pointer_append_date = .false.
 ::
 
 MED_attributes::

--- a/nuopc.runconfig
+++ b/nuopc.runconfig
@@ -36,10 +36,22 @@ PELAYOUT_attributes::
      cpl_pestride = 1
      cpl_rootpe = 0
      esmf_logging = ESMF_LOGKIND_NONE
+     esp_ntasks = 1
+     esp_nthreads = 1
+     esp_pestride = 1
+     esp_rootpe = 0
+     glc_ntasks = 1
+     glc_nthreads = 1
+     glc_pestride = 1
+     glc_rootpe = 0
      ice_ntasks = 24
      ice_nthreads = 1
      ice_pestride = 1
      ice_rootpe = 0
+     lnd_ntasks = 1
+     lnd_nthreads = 1
+     lnd_pestride = 1
+     lnd_rootpe = 0
      ninst = 1
      ocn_ntasks = 216
      ocn_nthreads = 1
@@ -52,6 +64,10 @@ PELAYOUT_attributes::
      rof_nthreads = 1
      rof_pestride = 1
      rof_rootpe = 0
+     wav_ntasks = 1
+     wav_nthreads = 1
+     wav_pestride = 1
+     wav_rootpe = 0
 ::
 
 component_list: MED ATM ICE OCN ROF
@@ -62,15 +78,15 @@ ALLCOMP_attributes::
      LND_model = slnd
      MED_model = cesm
      OCN_model = mom
-     ROF_model = drof
-     WAV_model = swav
      Profiling = 0
+     ROF_model = drof
      ScalarFieldCount = 4
      ScalarFieldIdxGridNX = 1
      ScalarFieldIdxGridNY = 2
      ScalarFieldIdxNextSwCday = 3
      ScalarFieldIdxPrecipFactor = 0
      ScalarFieldName = cpl_scalars
+     WAV_model = swav
      brnch_retain_casename = .false.
      case_desc = UNSET
      case_name = access-om3
@@ -78,9 +94,12 @@ ALLCOMP_attributes::
      coldair_outbreak_mod = .false.
      data_assimilation_atm = .false.
      data_assimilation_cpl = .false.
+     data_assimilation_glc = .false.
      data_assimilation_ice = .false.
+     data_assimilation_lnd = .false.
      data_assimilation_ocn = .false.
      data_assimilation_rof = .false.
+     data_assimilation_wav = .false.
      flds_bgc_oi = .false.
      flds_co2a = .false.
      flds_co2b = .false.
@@ -88,7 +107,6 @@ ALLCOMP_attributes::
      flds_i2o_per_cat = .false.
      flds_r2l_stream_channel_depths = .false.
      flds_wiso = .false.
-     add_gusts = .false.
      flux_convergence = 0.01
      flux_max_iteration = 5
      glc_nec = 10
@@ -99,6 +117,7 @@ ALLCOMP_attributes::
      ice_ncat = 5
      mediator_present = true
      mesh_atm = ./INPUT/access-om2-1deg-nomask-ESMFmesh.nc
+     mesh_glc = UNSET
      mesh_ice = ./INPUT/access-om2-1deg-ESMFmesh.nc
      mesh_lnd = UNSET
      mesh_mask = ./INPUT/access-om2-1deg-ESMFmesh.nc
@@ -118,7 +137,7 @@ ALLCOMP_attributes::
      start_type = startup
      tfreeze_option = linear_salt
      wav_coupling_to_cice = .false.
-     restart_pointer_append_date = .false.
+     write_restart_at_endofrun = .false.
 ::
 
 MED_attributes::
@@ -269,13 +288,13 @@ CLOCK_attributes::
      lnd_cpl_dt = 99999 #not used
      ocn_cpl_dt = 3600 #ignored (coupling timestep set by nuopc.runseq) unless stop_option is nsteps
      restart_n = 1
-     restart_option = nyears
+     restart_option = nmonths
      restart_ymd = -999
      rof_cpl_dt = 99999 #not used
      start_tod = 0
      start_ymd = 19000101
      stop_n = 1
-     stop_option = nyears
+     stop_option = nmonths
      stop_tod = 0
      stop_ymd = -999
      tprof_n = -999
@@ -296,6 +315,14 @@ ICE_attributes::
      Verbosity = off
 ::
 
+GLC_attributes::
+     Verbosity = off
+::
+
+LND_attributes::
+     Verbosity = off
+::
+
 OCN_attributes::
      Verbosity = off
 ::
@@ -305,28 +332,33 @@ ROF_attributes::
      mesh_rof = ./INPUT/access-om2-1deg-nomask-ESMFmesh.nc
 ::
 
+WAV_attributes::
+     Verbosity = off
+     mesh_wav = UNSET
+::
+
 MED_modelio::
      diro = ./log
      logfile = med.log
      pio_async_interface = .false.
-     pio_netcdf_format = nothing
-     pio_numiotasks = 4
+     pio_netcdf_format = 64bit_offset
+     pio_numiotasks = -99
      pio_rearranger = 2
      pio_root = 1
-     pio_stride = 1
-     pio_typename = netcdf4p
+     pio_stride = 48
+     pio_typename = netcdf
 ::
 
 ATM_modelio::
      diro = ./log
      logfile = atm.log
      pio_async_interface = .false.
-     pio_netcdf_format = nothing
-     pio_numiotasks = 1
+     pio_netcdf_format = 64bit_offset
+     pio_numiotasks = -99
      pio_rearranger = 1
      pio_root = 1
-     pio_stride = 1
-     pio_typename = netcdf4p
+     pio_stride = 48
+     pio_typename = netcdf
 ::
 
 ICE_modelio::
@@ -336,8 +368,8 @@ ICE_modelio::
      pio_netcdf_format = nothing
      pio_numiotasks = 1
      pio_rearranger = 1
-     pio_root = 1
-     pio_stride = 1
+     pio_root = 0
+     pio_stride = 48
      pio_typename = netcdf4p
 ::
 
@@ -356,16 +388,29 @@ OCN_modelio::
 ROF_modelio::
      diro = ./log
      logfile = rof.log
-     pio_async_interface = .false. 
-     pio_netcdf_format = nothing 
-     pio_numiotasks = 1 
-     pio_rearranger = 2 
-     pio_root = 1 
-     pio_stride = 1
-     pio_typename = netcdf4p 
+     pio_async_interface = .false. #not used
+     pio_netcdf_format = 64bit_offset #not used
+     pio_numiotasks = -99 #not used
+     pio_rearranger = 2 #not used
+     pio_root = 1 #not used
+     pio_stride = 48 #not used
+     pio_typename = netcdf #not used
+::
+
+WAV_modelio::
+     diro = ./log
+     logfile = wav.log
+     pio_async_interface = .false.
+     pio_netcdf_format = 64bit_offset
+     pio_numiotasks = -99
+     pio_rearranger = 2
+     pio_root = 1
+     pio_stride = 48
+     pio_typename = netcdf
 ::
 
 DRV_modelio::
      diro = ./log
      logfile = drv.log
 ::
+


### PR DESCRIPTION
All the tests use 

- FMS version 2023.02, unless a different version is explicitly specified in the commit message.
    - The first empty commit uses FMS 2024.03 in the 0.4.0 build.
- MOM without symmetric