### PR TITLE
Build with spack-packages 2025.03.001

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -45,9 +45,9 @@ userscripts:
 
 modules:
     use:
-        - /g/data/vk83/modules
+        - /g/data/vk83/prerelease/modules
     load:
-        - access-om3/2025.01.0
+        - access-om3/pr59-1
         - nco/5.0.5
 
 payu_minimum_version: 1.1.6


### PR DESCRIPTION
The PR uses a prerelease executable built using [`spack-packages` 2025.03.001](https://github.com/ACCESS-NRI/spack-packages/releases/tag/2025.03.001), meaning ESMF is compiled with `-fp-model precise`. With ACCESS-OM3 2025.01.0 we used [`spack-packages` 2024.07.08](https://github.com/ACCESS-NRI/ACCESS-OM3/blob/59f0e754c7bb471721fe81094c8476b9b67582a1/config/versions.json#L4), which doesn't include this compiler flag in the access-om3-nuopc spack package.

I think this has maybe been implicitly tested in other PRs, but it's easier/cleaner to open this than dig through those...
