### PR TITLE
Update to ACCESS-OM3 2025.01.1

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -47,7 +47,7 @@ modules:
     use:
         - /g/data/vk83/modules
     load:
-        - access-om3/2025.01.0
+        - access-om3/2025.01.1
         - nco/5.0.5
 
 payu_minimum_version: 1.1.6

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -2,7 +2,7 @@ format: yamanifest
 version: 1.0
 ---
 work/access-om3-MOM6-CICE6:
-  fullpath: /g/data/vk83/apps/spack/0.22/release/linux-rocky8-x86_64/intel-2021.10.0/access-om3-nuopc-git.0.4.0_0.4.0-bmecwy5vdmpxapbgqwbqsoi2y7rglaie/bin/access-om3-MOM6-CICE6
+  fullpath: /g/data/vk83/apps/spack/0.22/release/linux-rocky8-x86_64/intel-2021.10.0/access-om3-nuopc-git.0.4.0_0.4.0-6pn4blfzwmvvgtq6vny5pz53scfavi4z/bin/access-om3-MOM6-CICE6
   hashes:
-    binhash: 2edb3ca163da9ef9ef082a1fbdb98493
-    md5: 815f23c0339742798d5db37deb7b798e
+    binhash: 45d9665673a6b69f9fee337f048441a4
+    md5: 617efdc814bfbcb3d17950ecd68b26c5

--- a/testing/checksum/historical-3hr-checksum.json
+++ b/testing/checksum/historical-3hr-checksum.json
@@ -2,88 +2,88 @@
   "schema_version": "1-0-0",
   "output": {
     "CAu": [
-      "A4C51EC2A34D8EF1"
+      "7AA1A8D0B35605A1"
     ],
     "CAv": [
-      "DA7F07794C0B7279"
+      "751961C91E9D72CB"
     ],
     "DTBT": [
-      "4055968059DD63AF"
+      "4055968059DD63BE"
     ],
     "First_direction": [
       "0"
     ],
     "Kd_shear": [
-      "8A1CB3488BF7FAC7"
+      "A9DFF6F842ABD7DF"
     ],
     "Kv_shear": [
-      "55036CBF887185D4"
+      "6EA4428908C1DAC"
     ],
     "MEKE": [
-      "A205FF94D0736FD0"
+      "A28D7F96836A19EF"
     ],
     "MEKE_Kh": [
-      "C5E23A24466765D4"
+      "C5D09A9EBA927737"
     ],
     "MEKE_Kh_diff": [
-      "C62261CF4678ACEE"
+      "C6186FEF17B7D0B5"
     ],
     "MEKE_Ku": [
-      "A9959752C4D3DE41"
+      "A9C0BC8E8490C321"
     ],
     "MLD_MLE_filtered": [
-      "7463C5D823501487"
+      "7463A6E3F18B596B"
     ],
     "Salt": [
-      "8E3D02158AE4EAED"
+      "8E3E0E1CFAC6B550"
     ],
     "Temp": [
-      "E441AC22DEDE8930"
+      "E4F712A6C430613E"
     ],
     "age": [
-      "B64AD181B58D3F4B"
+      "B61C969E663DE9E3"
     ],
     "ave_ssh": [
-      "40E5A21D6F0D1F87"
+      "40E5B59E0088A2DC"
     ],
     "diffu": [
-      "749F723BA63A013C"
+      "E3AFE667B0CE60D9"
     ],
     "diffv": [
-      "CD7614674E679DA8"
+      "4914F152A406E829"
     ],
     "frazil": [
-      "5FE9C9F905239FC4"
+      "5FE9C87FF4989AF8"
     ],
     "h": [
-      "9138701970F7E8A"
+      "9139EFD0CD67B09"
     ],
     "h_ML": [
-      "A815BF54039C2D82"
+      "A82FBB8DC431A4ED"
     ],
     "p_surf_EOS": [
       "161DADB852A006F1"
     ],
     "sfc": [
-      "68FCD5E9DE45D1DF"
+      "E9DE6FD88A1447AB"
     ],
     "u": [
-      "803BF5B7E9C239C1"
+      "F952FDC75CA515CD"
     ],
     "u2": [
-      "32A58A90C668C32D"
+      "81B973F814BA0E79"
     ],
     "ubtav": [
-      "2E16365E105FFB9"
+      "82C9B045AAC9978E"
     ],
     "v": [
-      "7D9693C22E4D52B5"
+      "59F1E906D2743191"
     ],
     "v2": [
-      "DA212F15199DC960"
+      "C9D80DBA1468BC0D"
     ],
     "vbtav": [
-      "A6344B9A6D8CB3A9"
+      "A8862A266772DE71"
     ]
   }
 }


### PR DESCRIPTION
**1. Summary**:
This PR updates to ACCESS-OM3 2025.01.1 which:
- Reverts MOM to non-symmetric mode
- Compiles ESMF with `fp-model precise`

**2. Issues Addressed:**
https://github.com/COSIMA/access-om3/issues/299

**6. Reproducibility**
The expectation is that this will fail the historical repro test, but will pass the repeat and restart repro tests. UPDATE: expectation [confirmed by repro tests](https://github.com/ACCESS-NRI/access-om3-configs/pull/214#issuecomment-2712785869)