### PR TITLE
Update baroclinic, thermodynamic, coupling timesteps

### DIFF
--- a/MOM_input
+++ b/MOM_input
@@ -37,12 +37,12 @@ DT = 1080.0                     !   [s]
                                 ! The (baroclinic) dynamics time step.  The time-step that is actually used will
                                 ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
                                 ! or the coupling timestep in coupled mode.)
-DT_THERM = 10800.0              !   [s] default = 1080.0
+DT_THERM = 1.08E+04             !   [s] default = 1080.0
                                 ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
                                 ! an integer multiple of DT and less than the forcing or coupling time-step,
                                 ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
                                 ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
-THERMO_SPANS_COUPLING = True   !   [Boolean] default = False
+THERMO_SPANS_COUPLING = True    !   [Boolean] default = False
                                 ! If true, the MOM will take thermodynamic and tracer timesteps that can be
                                 ! longer than the coupling timestep. The actual thermodynamic timestep that is
                                 ! used in this case is the largest integer multiple of the coupling timestep
@@ -52,7 +52,7 @@ HFREEZE = 10.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-DTBT_RESET_PERIOD = 0.0         !   [s] default = 1350.0
+DTBT_RESET_PERIOD = 0.0         !   [s] default = 1.08E+04
                                 ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
                                 ! is negative, DTBT is set based only on information available at
                                 ! initialization.  If 0, DTBT will be set every dynamics time step. The default

--- a/MOM_input
+++ b/MOM_input
@@ -33,10 +33,20 @@ THICKNESSDIFFUSE = True         !   [Boolean] default = False
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
                                 ! If true, do thickness diffusion or interface height smoothing before dynamics.
                                 ! This is only used if THICKNESSDIFFUSE or APPLY_INTERFACE_FILTER is true.
-DT = 1350.0                     !   [s]
+DT = 1080.0                     !   [s]
                                 ! The (baroclinic) dynamics time step.  The time-step that is actually used will
                                 ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
                                 ! or the coupling timestep in coupled mode.)
+DT_THERM = 10800.0              !   [s] default = 1080.0
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
+THERMO_SPANS_COUPLING = True   !   [Boolean] default = False
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HFREEZE = 10.0                  !   [m] default = -1.0
                                 ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the

--- a/docs/MOM_parameter_doc.all
+++ b/docs/MOM_parameter_doc.all
@@ -68,16 +68,16 @@ BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
                                 ! If true, there are separate values for the basin depths at velocity points.
                                 ! Otherwise the effects of topography are entirely determined from thickness
                                 ! points.
-DT = 1350.0                     !   [s]
+DT = 1080.0                     !   [s]
                                 ! The (baroclinic) dynamics time step.  The time-step that is actually used will
                                 ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
                                 ! or the coupling timestep in coupled mode.)
-DT_THERM = 1350.0               !   [s] default = 1350.0
+DT_THERM = 1.08E+04             !   [s] default = 1080.0
                                 ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
                                 ! an integer multiple of DT and less than the forcing or coupling time-step,
                                 ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
                                 ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
-THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
+THERMO_SPANS_COUPLING = True    !   [Boolean] default = False
                                 ! If true, the MOM will take thermodynamic and tracer timesteps that can be
                                 ! longer than the coupling timestep. The actual thermodynamic timestep that is
                                 ! used in this case is the largest integer multiple of the coupling timestep
@@ -98,7 +98,7 @@ HFREEZE = 10.0                  !   [m] default = -1.0
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
-DTBT_RESET_PERIOD = 0.0         !   [s] default = 1350.0
+DTBT_RESET_PERIOD = 0.0         !   [s] default = 1.08E+04
                                 ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
                                 ! is negative, DTBT is set based only on information available at
                                 ! initialization.  If 0, DTBT will be set every dynamics time step. The default

--- a/docs/MOM_parameter_doc.short
+++ b/docs/MOM_parameter_doc.short
@@ -9,16 +9,26 @@ THICKNESSDIFFUSE = True         !   [Boolean] default = False
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
                                 ! If true, do thickness diffusion or interface height smoothing before dynamics.
                                 ! This is only used if THICKNESSDIFFUSE or APPLY_INTERFACE_FILTER is true.
-DT = 1350.0                     !   [s]
+DT = 1080.0                     !   [s]
                                 ! The (baroclinic) dynamics time step.  The time-step that is actually used will
                                 ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
                                 ! or the coupling timestep in coupled mode.)
+DT_THERM = 1.08E+04             !   [s] default = 1080.0
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
+THERMO_SPANS_COUPLING = True    !   [Boolean] default = False
+                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
+                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
+                                ! used in this case is the largest integer multiple of the coupling timestep
+                                ! that is less than or equal to DT_THERM.
 HFREEZE = 10.0                  !   [m] default = -1.0
                                 ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-DTBT_RESET_PERIOD = 0.0         !   [s] default = 1350.0
+DTBT_RESET_PERIOD = 0.0         !   [s] default = 1.08E+04
                                 ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
                                 ! is negative, DTBT is set based only on information available at
                                 ! initialization.  If 0, DTBT will be set every dynamics time step. The default

--- a/nuopc.runconfig
+++ b/nuopc.runconfig
@@ -267,7 +267,7 @@ CLOCK_attributes::
      history_ymd = -999
      ice_cpl_dt = 99999 #not used
      lnd_cpl_dt = 99999 #not used
-     ocn_cpl_dt = 1350 #ignored (coupling timestep set by nuopc.runseq) unless stop_option is nsteps
+     ocn_cpl_dt = 1080 #ignored (coupling timestep set by nuopc.runseq) unless stop_option is nsteps
      restart_n = 1
      restart_option = nyears
      restart_ymd = -999

--- a/nuopc.runseq
+++ b/nuopc.runseq
@@ -1,5 +1,5 @@
 runSeq:: 
-@1350 
+@1080
   MED med_phases_aofluxes_run
   MED med_phases_prep_ocn_accum
   MED med_phases_ocnalb_run

--- a/testing/checksum/historical-3hr-checksum.json
+++ b/testing/checksum/historical-3hr-checksum.json
@@ -1,89 +1,89 @@
 {
   "schema_version": "1-0-0",
   "output": {
-    "Salt": [
-      "125F56FFA18F612A"
-    ],
-    "Temp": [
-      "858E5B96510A23D"
-    ],
-    "h": [
-      "5ED930A383F05F7F"
-    ],
-    "u": [
-      "4E3DCE1272B6E187"
-    ],
-    "CAu": [
-      "9EBDA922C5AB62BA"
-    ],
     "First_direction": [
       "0"
     ],
+    "Salt": [
+      "C2C1BE2C4DC8B472"
+    ],
+    "Temp": [
+      "F8FCCB5F2111FD7D"
+    ],
     "ave_ssh": [
-      "F6E791DF6E46E85E"
+      "B544246749005DBA"
     ],
     "frazil": [
-      "1A5582248DBD8A68"
+      "8169AB4E1592FD3E"
+    ],
+    "h": [
+      "2F1C26C2863C414B"
     ],
     "p_surf_EOS": [
-      "FD7C640B0F57DCEB"
+      "D9B16A3BF48C3E9"
     ],
     "sfc": [
-      "7FD75C3A3729E1B6"
+      "E5C1EC3F36035C7A"
+    ],
+    "u": [
+      "ED62902C1A641884"
     ],
     "u2": [
-      "33E7DA852ADC6D25"
+      "E77A24B946747D77"
     ],
     "v": [
-      "B39167D5978CB70E"
+      "3C7B163348EBF3A1"
     ],
-    "v2": [
-      "FA730E83B134B74"
+    "CAu": [
+      "BC4679B3EA7B55C9"
     ],
     "CAv": [
-      "45AB6898A5FF3192"
+      "D6226664418B1FCD"
     ],
     "DTBT": [
-      "4033E47ADF7C8784"
+      "4034AA96F8046668"
     ],
     "MEKE": [
-      "D1C191091AD4D654"
+      "6FF45E0AF5B2FD9F"
     ],
     "MEKE_Kh": [
-      "B83A416159B2C8CD"
+      "0"
     ],
     "MEKE_Kh_diff": [
-      "25B1BC3B29740D0C"
+      "0"
     ],
     "MEKE_Ku": [
-      "EF036CC8E6796922"
+      "658383A4CBDD0EC8"
     ],
     "age": [
-      "9796E446F474BEF7"
+      "18CA48AACAB763A0"
     ],
     "diffu": [
-      "CE1EE99C054B59D7"
+      "23DE5F82925F14AF"
     ],
     "diffv": [
-      "79D1B6B0E73BB65"
+      "D220240C76B68A1D"
     ],
     "ubtav": [
-      "5E619670656B421F"
+      "391BC5EBB3245432"
+    ],
+    "v2": [
+      "BEA9C5E16882A6AC"
     ],
     "vbtav": [
-      "EDF63C9269687095"
+      "BE32B2EC93C4E710"
     ],
     "Kd_shear": [
-      "FB1C4199D43782B6"
+      "1DBDB60ACF537A1E"
     ],
     "Kv_shear": [
-      "20DB6A549974E426"
+      "EC128A840565E2C4"
     ],
     "MLD_MLE_filtered": [
-      "FD422385077B771C"
+      "A255AD1F393CBA76"
     ],
     "h_ML": [
-      "D7C8CAF430721CD1"
+      "FB5E1F6DFB8284F3"
     ]
   }
 }

--- a/testing/checksum/historical-3hr-checksum.json
+++ b/testing/checksum/historical-3hr-checksum.json
@@ -1,50 +1,53 @@
 {
   "schema_version": "1-0-0",
   "output": {
+    "Salt": [
+      "A3E2BC3B76E3BE31"
+    ],
+    "Temp": [
+      "696C1EA687F914CB"
+    ],
+    "h": [
+      "6181C00B006A4198"
+    ],
+    "u": [
+      "E20700CBA5286741"
+    ],
+    "CAu": [
+      "3C19C6995DC0E976"
+    ],
     "First_direction": [
       "0"
     ],
-    "Salt": [
-      "C2C1BE2C4DC8B472"
-    ],
-    "Temp": [
-      "F8FCCB5F2111FD7D"
-    ],
     "ave_ssh": [
-      "B544246749005DBA"
+      "E6AE0C8219DBC675"
     ],
     "frazil": [
-      "8169AB4E1592FD3E"
-    ],
-    "h": [
-      "2F1C26C2863C414B"
+      "42B68BCBC470A0D7"
     ],
     "p_surf_EOS": [
-      "D9B16A3BF48C3E9"
+      "FD15FF92AFF2FCE8"
     ],
     "sfc": [
-      "E5C1EC3F36035C7A"
-    ],
-    "u": [
-      "ED62902C1A641884"
+      "BADE7A7A5468651C"
     ],
     "u2": [
-      "E77A24B946747D77"
+      "70EA04C45BFF9013"
     ],
     "v": [
-      "3C7B163348EBF3A1"
+      "F8E6DCDBE8959BFE"
     ],
-    "CAu": [
-      "BC4679B3EA7B55C9"
+    "v2": [
+      "38C9FB806A616"
     ],
     "CAv": [
-      "D6226664418B1FCD"
+      "D3F9C05019FBE833"
     ],
     "DTBT": [
-      "4034AA96F8046668"
+      "4033E47AA9D4E8E1"
     ],
     "MEKE": [
-      "6FF45E0AF5B2FD9F"
+      "BE627B31713B4B57"
     ],
     "MEKE_Kh": [
       "0"
@@ -53,37 +56,34 @@
       "0"
     ],
     "MEKE_Ku": [
-      "658383A4CBDD0EC8"
+      "351E776DA1BA3680"
     ],
     "age": [
-      "18CA48AACAB763A0"
+      "53DCBD80629A29A7"
     ],
     "diffu": [
-      "23DE5F82925F14AF"
+      "30ADF8B09E98F254"
     ],
     "diffv": [
-      "D220240C76B68A1D"
+      "1D276CFDD82BBFBE"
     ],
     "ubtav": [
-      "391BC5EBB3245432"
-    ],
-    "v2": [
-      "BEA9C5E16882A6AC"
+      "50B7C7792B5A9443"
     ],
     "vbtav": [
-      "BE32B2EC93C4E710"
+      "26CB5386CC0563AE"
     ],
     "Kd_shear": [
-      "1DBDB60ACF537A1E"
+      "7FF69CB71452D3E9"
     ],
     "Kv_shear": [
-      "EC128A840565E2C4"
+      "A83CDD7FF5FFE50B"
     ],
     "MLD_MLE_filtered": [
-      "A255AD1F393CBA76"
+      "497762A038096556"
     ],
     "h_ML": [
-      "FB5E1F6DFB8284F3"
+      "BFE93CB7242F6471"
     ]
   }
 }


### PR DESCRIPTION
**1. Summary**:
<!-- summarise the changes -->
The PR updates ocean dynamic, tracer timesteps along with coupling timestep. 

**2. Issues Addressed:**
<!-- Add links to github issue(s) this is related to -->
- https://github.com/COSIMA/access-om3/issues/138


**3. Documentation**
<!--Does this impact documentation? Has the wiki been updated? Have the `docs/MOM_*` files been updated ?-->
- With the current timestep setup, running performance has significantly improved, especially for MOM6, making it comparable to MOM5 when using a similar number of CPU cores over a 10-day run (without diagnostics). However, the total runtime is not fully optimised due to load imbalance in the NUOPC coupling. This will be addressed later in another PR. 
- Additional documentation and details can be found under current PR: https://github.com/ACCESS-NRI/access-om3-configs/pull/223#issuecomment-2739379301