### PR TITLE
Turn on mom supergrid in  dev mc 1deg jra ryf

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -29,7 +29,6 @@ input:
     - /g/data/vk83/configurations/inputs/access-om3/mom/grids/vertical/global.1deg/2023.07.28/ocean_vgrid.nc
     - /g/data/vk83/configurations/inputs/access-om3/mom/initial_conditions/global.1deg/2020.10.22/ocean_temp_salt.res.nc
     - /g/data/vk83/configurations/inputs/access-om3/mom/surface_salt_restoring/global.1deg/2020.05.30/salt_sfc_restore.nc
-    - /g/data/vk83/configurations/inputs/access-om3/cice/grids/global.1deg/2024.05.14/grid.nc
     - /g/data/vk83/configurations/inputs/access-om3/cice/grids/global.1deg/2024.05.14/kmt.nc
     - /g/data/vk83/configurations/inputs/access-om3/cice/initial_conditions/global.1deg/2023.07.28/iced.1900-01-01-10800.nc
     - /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data
@@ -47,7 +46,7 @@ modules:
     use:
         - /g/data/vk83/modules
     load:
-        - access-om3/2025.01.1
+        - access-om3/2025.01.2
         - nco/5.0.5
 
 payu_minimum_version: 1.1.6

--- a/docs/MOM_parameter_doc.layout
+++ b/docs/MOM_parameter_doc.layout
@@ -7,7 +7,7 @@ GLOBAL_INDEXING = False         !   [Boolean] default = False
                                 ! static memory.
 
 ! === module MOM_domains ===
-!SYMMETRIC_MEMORY_ = True       !   [Boolean]
+!SYMMETRIC_MEMORY_ = False      !   [Boolean]
                                 ! If defined, the velocity point data domain includes every face of the
                                 ! thickness points. In other words, some arrays are larger than others,
                                 ! depending on where they are on the staggered grid.  Also, the starting index

--- a/ice_in
+++ b/ice_in
@@ -19,8 +19,8 @@
 &grid_nml
   bathymetry_file = "./INPUT/topog.nc"
   grid_atm = "A"
-  grid_file = "./INPUT/grid.nc"
-  grid_format = "nc"
+  grid_file = "./INPUT/ocean_hgrid.nc"
+  grid_format = "mom_nc"
   grid_ice = "B"
   grid_ocn = "A"
   grid_type = "tripole"

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -2,7 +2,7 @@ format: yamanifest
 version: 1.0
 ---
 work/access-om3-MOM6-CICE6:
-  fullpath: /g/data/vk83/apps/spack/0.22/release/linux-rocky8-x86_64/intel-2021.10.0/access-om3-nuopc-git.0.4.0_0.4.0-6pn4blfzwmvvgtq6vny5pz53scfavi4z/bin/access-om3-MOM6-CICE6
+  fullpath: /g/data/vk83/apps/spack/0.22/release/linux-rocky8-x86_64/intel-2021.10.0/access-om3-nuopc-git.0.4.1_0.4.1-da4dcqojvm4siufkyf3fifawf5tpjlfu/bin/access-om3-MOM6-CICE6
   hashes:
-    binhash: 45d9665673a6b69f9fee337f048441a4
-    md5: 617efdc814bfbcb3d17950ecd68b26c5
+    binhash: 4e921c28f229aa272c853de61e34cb99
+    md5: 23e5622d1f50742e07554ebdd8cb23b3

--- a/manifests/input.yaml
+++ b/manifests/input.yaml
@@ -81,11 +81,6 @@ work/INPUT/access-om2-1deg-nomask-ESMFmesh.nc:
   hashes:
     binhash: 4b1cc45032afeaf93b4894937639f5b9
     md5: 9b7120a42b5cb587492e7c31791eb549
-work/INPUT/grid.nc:
-  fullpath: /g/data/vk83/configurations/inputs/access-om3/cice/grids/global.1deg/2024.05.14/grid.nc
-  hashes:
-    binhash: b347eb0588291c34bb40a24a7bc45173
-    md5: 544a40b634c182f3e182da6bcbe8be7b
 work/INPUT/iced.1900-01-01-10800.nc:
   fullpath: /g/data/vk83/configurations/inputs/access-om3/cice/initial_conditions/global.1deg/2023.07.28/iced.1900-01-01-10800.nc
   hashes:

--- a/testing/checksum/historical-3hr-checksum.json
+++ b/testing/checksum/historical-3hr-checksum.json
@@ -2,88 +2,88 @@
   "schema_version": "1-0-0",
   "output": {
     "CAu": [
-      "7AA1A8D0B35605A1"
+      "E93C4D9B328E1BCD"
     ],
     "CAv": [
-      "751961C91E9D72CB"
+      "D6CD2D7047FE4FE5"
     ],
     "DTBT": [
-      "4055968059DD63BE"
+      "405596805C05D2BF"
     ],
     "First_direction": [
       "0"
     ],
     "Kd_shear": [
-      "A9DFF6F842ABD7DF"
+      "7DCEA73F87DCC3A9"
     ],
     "Kv_shear": [
-      "6EA4428908C1DAC"
+      "89234A7BA91ECBE7"
     ],
     "MEKE": [
-      "A28D7F96836A19EF"
+      "A3B9A6B282DD2475"
     ],
     "MEKE_Kh": [
-      "C5D09A9EBA927737"
+      "C94B964EDB4FF62D"
     ],
     "MEKE_Kh_diff": [
-      "C6186FEF17B7D0B5"
+      "C75A6A041F808331"
     ],
     "MEKE_Ku": [
-      "A9C0BC8E8490C321"
+      "ACBE2761C0253D26"
     ],
     "MLD_MLE_filtered": [
-      "7463A6E3F18B596B"
+      "6D48D9EA43E3698B"
     ],
     "Salt": [
-      "8E3E0E1CFAC6B550"
+      "8D2CBD061AF4B1FD"
     ],
     "Temp": [
-      "E4F712A6C430613E"
+      "FB5F782BD7F66A46"
     ],
     "age": [
-      "B61C969E663DE9E3"
+      "F3A1C9BBD478F561"
     ],
     "ave_ssh": [
-      "40E5B59E0088A2DC"
+      "40E61D51908F73A8"
     ],
     "diffu": [
-      "E3AFE667B0CE60D9"
+      "BD425C0BC3728828"
     ],
     "diffv": [
-      "4914F152A406E829"
+      "1FE6547676A4F468"
     ],
     "frazil": [
-      "5FE9C87FF4989AF8"
+      "F5A580578E2F635"
     ],
     "h": [
-      "9139EFD0CD67B09"
+      "9189E9E7AA36BD7"
     ],
     "h_ML": [
-      "A82FBB8DC431A4ED"
+      "A7D72487C0E7B40C"
     ],
     "p_surf_EOS": [
       "161DADB852A006F1"
     ],
     "sfc": [
-      "E9DE6FD88A1447AB"
+      "ECDCE9C1C21E4B66"
     ],
     "u": [
-      "F952FDC75CA515CD"
+      "EB8A4CFC9881747"
     ],
     "u2": [
-      "81B973F814BA0E79"
+      "4DA25EE3A7E3C934"
     ],
     "ubtav": [
-      "82C9B045AAC9978E"
+      "7EB993213365EF6A"
     ],
     "v": [
-      "59F1E906D2743191"
+      "E183C60A9C519316"
     ],
     "v2": [
-      "C9D80DBA1468BC0D"
+      "19AA0C09093238D1"
     ],
     "vbtav": [
-      "A8862A266772DE71"
+      "9FA048DA8CE3A066"
     ]
   }
 }


### PR DESCRIPTION
**1. Summary**:
This fixes a small bug in the implementation of loading the mom hgrid file in CICE and turns on using this feature in the CICE configuration.

**2. Issues Addressed:**
#452 

**3. Depedencies (e.g. on payu, model or om3-scripts)**
Needs access-om3 deployment 2025.01.2

**4. Ad-hoc Testing**
Ran for 1 year with no truncations

**5. CI Testing**
Will trigger below

**6. Reproducibility**
<!-- Is this reproducible with the previous commit? (If not, why not?) -->
No - build doesn't change answers but changing the grid does changes answers


**7. Documentation**
<!--Does this impact documentation? Has the wiki been updated? Have the `docs/MOM_*` files been updated ?-->

We should update the "grids" subsection in the old wiki - @chrisb13 - is there a documentation branch where this change should go ?

**8. Formatting**
<!-- Are changes to MOM_input in the same order as docs/MOM_input? -->

I think i remember to update manifests, no changes to MOM_input/parameter docs.

**9. Merge Strategy**
<!-- What is the planned merge strategy (Merge commit, Rebase and merge, or squash) ?
If not squash, link to the related issue in the commit descriptions -->

Merge commit