### PR TITLE
Cherry-pick diag_table to dev-MC_1deg_jra_ryf+wombatlite

### DIFF
--- a/diag_table
+++ b/diag_table
@@ -1,232 +1,662 @@
-"MOM6 diagnostic fields table"
-1 1 1 0 0 0
-### Section-1: File List
-#========================
-"access-om3.mom6.h.rho2%4yr-%2mo",                      1,  "months", 1, "days",   "time", 1, "months"
-"access-om3.mom6.h.native%4yr-%2mo",                    1,  "months", 1, "days",   "time", 1, "months"
-"access-om3.mom6.h.z%4yr-%2mo",                         1,  "months", 1, "days",   "time", 1, "months"
-"access-om3.mom6.h.sfc%4yr-%2mo",                       1,  "days",   1, "days",   "time", 1, "months"
-"access-om3.mom6.h.static",                             -1, "days",   1, "days",   "time"
-"access-om3.mom6.h.wombatlite%4yr-%2mo",                1,  "months", 1, "days",   "time", 1, "years"
+ACCESS-OM3
+1900 1 1 0 0 0
 
-### Section-2: Fields List
-#=========================
-# "access-om3.mom6.h.rho2%4yr-%2mo"
-"ocean_model_rho2", "volcello","volcello","access-om3.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_rho2", "vmo",     "vmo",     "access-om3.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_rho2", "vhGM",    "vhGM",    "access-om3.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_rho2", "vhml",    "vhml",    "access-om3.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_rho2", "umo",     "umo",     "access-om3.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_rho2", "uhGM",    "uhGM",    "access-om3.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_rho2", "uhml",    "uhml",    "access-om3.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_rho2", "thetao",  "thetao",  "access-om3.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_rho2", "so",      "so",      "access-om3.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_rho2", "agessc",  "agessc",  "access-om3.mom6.h.rho2%4yr-%2mo", "all", "mean", "none", 2
+#########################################################################################################
+#                                                                                                       #
+# DO NOT EDIT! Instead, edit diag_table_source.yaml and run make_diag_table.py to re-generate this file #
+#                                                                                                       #
+#########################################################################################################
 
-# "access-om3.mom6.h.native%4yr-%2mo"
-"ocean_model", "soga",         "soga",         "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "thetaoga",     "thetaoga",     "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "uh",           "uh",           "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "vh",           "vh",           "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "vhbt",         "vhbt",         "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "uhbt",         "uhbt",         "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "agessc",       "agessc",       "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "T_ady_2d",     "T_ady_2d",     "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "T_adx_2d",     "T_adx_2d",     "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "T_diffy_2d",   "T_diffy_2d",   "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "T_diffx_2d",   "T_diffx_2d",   "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "diftrelo",     "diftrelo",     "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "diftrblo",     "diftrblo",     "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "difmxybo",     "difmxybo",     "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "difmxylo",     "difmxylo",     "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "volcello",     "volcello",     "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "vmo",          "vmo",          "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "vhGM",         "vhGM",         "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "vhml",         "vhml",         "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "umo",          "umo",          "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "uhGM",         "uhGM",         "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "uhml",         "uhml",         "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "uo",           "uo",           "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "vo",           "vo",           "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "h",            "h",            "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "e",            "e",            "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "thetao",       "thetao",       "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "so",           "so",           "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "KE",           "KE",           "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "rhopot0",      "rhopot0",      "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "KPP_OBLdepth", "oml",          "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "tauuo",        "tauuo",        "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "tauvo",        "tauvo",        "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "friver",       "friver",       "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "prsn",         "prsn",         "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "prlq",         "prlq",         "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "evs",          "evs",          "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "hfsso",        "hfsso",        "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "rlntds",       "rlntds",       "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "hfsnthermds",  "hfsnthermds",  "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "sfdsi",        "sfdsi",        "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "rsntds",       "rsntds",       "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "hfds",         "hfds",         "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "ustar",        "ustar",        "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "hfsifrazil",   "hfsifrazil",   "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "wfo",          "wfo",          "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "vprec",        "vprec",        "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "ficeberg",     "ficeberg",     "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "fsitherm",     "fsitherm",     "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "hflso",        "hflso",        "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "pso",          "pso",          "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "seaice_melt_heat","seaice_melt_heat","access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "Heat_PmE",     "Heat_PmE",     "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "salt_flux_added","salt_flux_added","access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "heat_content_lrunoff","heat_content_lrunoff","access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "heat_content_frunoff","heat_content_frunoff","access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "heat_content_lprec","heat_content_lprec","access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "heat_content_fprec","heat_content_fprec","access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "heat_content_vprec","heat_content_vprec","access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "heat_content_cond","heat_content_cond","access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "heat_content_evap","heat_content_evap","access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "SSH",          "SSH",          "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "tos",          "tos",          "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "sos",          "sos",          "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "SSU",          "SSU",          "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "SSV",          "SSV",          "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "mass_wt",      "mass_wt",      "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "opottempmint", "opottempmint", "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "somint",       "somint",       "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "Rd_dx",        "Rd_dx",        "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "speed",        "speed",        "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "mlotst",       "mlotst",       "access-om3.mom6.h.native%4yr-%2mo", "all", "mean", "none", 2
 
-# "access-om3.mom6.h.z%4yr-%2mo"
-"ocean_model_z", "uo",      "uo",      "access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_z", "vo",      "vo",      "access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_z", "h",       "h",       "access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_z", "thetao",  "thetao",  "access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_z", "so",      "so",      "access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_z", "agessc",  "agessc",  "access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_z", "rhopot0", "rhopot0", "access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_z", "N2_int",  "N2_int",  "access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_z", "volcello","volcello","access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_z", "vmo",     "vmo",     "access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_z", "vhGM",    "vhGM",    "access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_z", "vhml",    "vhml",    "access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_z", "umo",     "umo",     "access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_z", "uhGM",    "uhGM",    "access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model_z", "uhml",    "uhml",    "access-om3.mom6.h.z%4yr-%2mo", "all", "mean", "none", 2
+# static 2d grid data
 
-# "access-om3.mom6.h.sfc%4yr-%2mo"
-"ocean_model", "SSH",          "SSH",          "access-om3.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "tos",          "tos",          "access-om3.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "sos",          "sos",          "access-om3.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "SSU",          "SSU",          "access-om3.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "SSV",          "SSV",          "access-om3.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "mass_wt",      "mass_wt",      "access-om3.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "opottempmint", "opottempmint", "access-om3.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "somint",       "somint",       "access-om3.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "Rd_dx",        "Rd_dx",        "access-om3.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "speed",        "speed",        "access-om3.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "mlotst",       "mlotst",       "access-om3.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
-"ocean_model", "KPP_OBLdepth", "oml",          "access-om3.mom6.h.sfc%4yr-%2mo", "all", "mean", "none", 2
+"access-om3.mom6.static", -1, "months", 1, "days", "time"
+"ocean_model", "areacello", "areacello", "access-om3.mom6.static", "all", "none", "none", 1
+"ocean_model", "areacello_cu", "areacello_cu", "access-om3.mom6.static", "all", "none", "none", 1
+"ocean_model", "areacello_cv", "areacello_cv", "access-om3.mom6.static", "all", "none", "none", 1
+"ocean_model", "areacello_bu", "areacello_bu", "access-om3.mom6.static", "all", "none", "none", 1
+"ocean_model", "dxt", "dxt", "access-om3.mom6.static", "all", "none", "none", 1
+"ocean_model", "dyt", "dyt", "access-om3.mom6.static", "all", "none", "none", 1
+"ocean_model", "geolat_c", "geolat_c", "access-om3.mom6.static", "all", "none", "none", 1
+"ocean_model", "geolat", "geolat", "access-om3.mom6.static", "all", "none", "none", 1
+"ocean_model", "geolat_u", "geolat_u", "access-om3.mom6.static", "all", "none", "none", 1
+"ocean_model", "geolat_v", "geolat_v", "access-om3.mom6.static", "all", "none", "none", 1
+"ocean_model", "geolon_c", "geolon_c", "access-om3.mom6.static", "all", "none", "none", 1
+"ocean_model", "geolon", "geolon", "access-om3.mom6.static", "all", "none", "none", 1
+"ocean_model", "geolon_u", "geolon_u", "access-om3.mom6.static", "all", "none", "none", 1
+"ocean_model", "geolon_v", "geolon_v", "access-om3.mom6.static", "all", "none", "none", 1
+"ocean_model", "deptho", "deptho", "access-om3.mom6.static", "all", "none", "none", 1
+"ocean_model", "wet", "wet", "access-om3.mom6.static", "all", "none", "none", 1
+"ocean_model", "wet_c", "wet_c", "access-om3.mom6.static", "all", "none", "none", 1
+"ocean_model", "wet_u", "wet_u", "access-om3.mom6.static", "all", "none", "none", 1
+"ocean_model", "wet_v", "wet_v", "access-om3.mom6.static", "all", "none", "none", 1
+"ocean_model", "Coriolis", "Coriolis", "access-om3.mom6.static", "all", "none", "none", 1
+"ocean_model", "sin_rot", "sin_rot", "access-om3.mom6.static", "all", "none", "none", 1
+"ocean_model", "cos_rot", "cos_rot", "access-om3.mom6.static", "all", "none", "none", 1
+"ocean_model", "dxCu", "dxCu", "access-om3.mom6.static", "all", "none", "none", 1
+"ocean_model", "dyCu", "dyCu", "access-om3.mom6.static", "all", "none", "none", 1
+"ocean_model", "dxCv", "dxCv", "access-om3.mom6.static", "all", "none", "none", 1
+"ocean_model", "dyCv", "dyCv", "access-om3.mom6.static", "all", "none", "none", 1
+"ocean_model", "dyCuo", "dyCuo", "access-om3.mom6.static", "all", "none", "none", 1
+"ocean_model", "dxCvo", "dxCvo", "access-om3.mom6.static", "all", "none", "none", 1
 
-# "access-om3.mom6.h.static"
-"ocean_model", "geolon",      "geolon",      "access-om3.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "geolat",      "geolat",      "access-om3.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "geolon_c",    "geolon_c",    "access-om3.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "geolat_c",    "geolat_c",    "access-om3.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "geolon_u",    "geolon_u",    "access-om3.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "geolat_u",    "geolat_u",    "access-om3.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "geolon_v",    "geolon_v",    "access-om3.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "geolat_v",    "geolat_v",    "access-om3.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "deptho",      "deptho",      "access-om3.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "wet",         "wet",         "access-om3.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "wet_c",       "wet_c",       "access-om3.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "wet_u",       "wet_u",       "access-om3.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "wet_v",       "wet_v",       "access-om3.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "Coriolis",    "Coriolis",    "access-om3.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "areacello",   "areacello",   "access-om3.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "areacello_cu","areacello_cu","access-om3.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "areacello_cv","areacello_cv","access-om3.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "areacello_bu","areacello_bu","access-om3.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "sin_rot",     "sin_rot",     "access-om3.mom6.h.static", "all", ".false.", "none", 2
-"ocean_model", "cos_rot",     "cos_rot",     "access-om3.mom6.h.static", "all", ".false.", "none", 2
 
-# "access-om3.mom6.h.wombatlite%4yr-%2mo"
-"ocean_model",        "volcello",           "volcello",           "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "pco2",               "pco2",               "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "paco2",              "paco2",              "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "light_limit",        "light_limit",        "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "radbio3d",           "radbio3d",           "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "radbio1",            "radbio1",            "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "det_sed_remin",      "det_sed_remin",      "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "det_sed_depst",      "det_sed_depst",      "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "caco3_sed_remin",    "caco3_sed_remin",    "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "caco3_sed_depst",    "caco3_sed_depst",    "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "wdet100",            "wdet100",            "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "npp3d",              "npp3d",              "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "npp2d",              "npp2d",              "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "npp1",               "npp1",               "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "pprod_gross",        "pprod_gross",        "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "pprod_gross_2d",     "pprod_gross_2d",     "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "zprod_gross",        "zprod_gross",        "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "dic_intmld",         "dic_intmld",         "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "adic_intmld",        "adic_intmld",        "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "o2_intmld",          "o2_intmld",          "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "no3_intmld",         "no3_intmld",         "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "fe_intmld",          "fe_intmld",          "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "phy_intmld",         "phy_intmld",         "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "det_intmld",         "det_intmld",         "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "pprod_gross_intmld", "pprod_gross_intmld", "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "npp_intmld",         "npp_intmld",         "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "radbio_intmld",      "radbio_intmld",      "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "dic_int100",         "dic_int100",         "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "adic_int100",        "adic_int100",        "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "o2_int100",          "o2_int100",          "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "no3_int100",         "no3_int100",         "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "fe_int100",          "fe_int100",          "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "phy_int100",         "phy_int100",         "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "det_int100",         "det_int100",         "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "pprod_gross_int100", "pprod_gross_int100", "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "npp_int100",         "npp_int100",         "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "radbio_int100",      "radbio_int100",      "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "no3",                "no3",                "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "no3_stf",            "no3_stf",            "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "no3_vstf",           "no3_vstf",           "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "no3_btf",            "no3_btf",            "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "phy",                "phy",                "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "phy_stf",            "phy_stf",            "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "phy_trunoff",        "phy_trunoff",        "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "o2",                 "o2",                 "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "o2_stf",             "o2_stf",             "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "o2_stf_gas",         "o2_stf_gas",         "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "o2_btf",             "o2_btf",             "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "o2_alpha",           "o2_alpha",           "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "o2_csurf",           "o2_csurf",           "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "o2_sc_no",           "o2_sc_no",           "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "zoo",                "zoo",                "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "det",                "det",                "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "caco3",              "caco3",              "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "adic",               "adic",               "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "adic_stf",           "adic_stf",           "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "adic_stf_gas",       "adic_stf_gas",       "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "adic_vstf",          "adic_vstf",          "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "adic_btf",           "adic_btf",           "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "adic_alpha",         "adic_alpha",         "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "adic_csurf",         "adic_csurf",         "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "adic_sc_no",         "adic_sc_no",         "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "dic",                "dic",                "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "dic_stf",            "dic_stf",            "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "dic_stf_gas",        "dic_stf_gas",        "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "dic_vstf",           "dic_vstf",           "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "dic_btf",            "dic_btf",            "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "dic_alpha",          "dic_alpha",          "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "dic_csurf",          "dic_csurf",          "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "dic_sc_no",          "dic_sc_no",          "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "alk",                "alk",                "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "alk_stf",            "alk_stf",            "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "alk_vstf",           "alk_vstf",           "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "alk_btf",            "alk_btf",            "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "fe",                 "fe",                 "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "fe_stf",             "fe_stf",             "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "fe_btf",             "fe_btf",             "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "det_sediment",       "det_sediment",       "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
-"generic_wombatlite", "caco3_sediment",     "caco3_sediment",     "access-om3.mom6.h.wombatlite%4yr-%2mo", "all", "mean", "none", 2
+# monthly 3d fields
+
+"access-om3.mom6.3d.h.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "h", "h", "access-om3.mom6.3d.h.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.e.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "e", "e", "access-om3.mom6.3d.e.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.agessc.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "agessc", "agessc", "access-om3.mom6.3d.agessc.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.difmxybo.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "difmxybo", "difmxybo", "access-om3.mom6.3d.difmxybo.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.difmxylo.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "difmxylo", "difmxylo", "access-om3.mom6.3d.difmxylo.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.diftrelo.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "diftrelo", "diftrelo", "access-om3.mom6.3d.diftrelo.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.diftrblo.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "diftrblo", "diftrblo", "access-om3.mom6.3d.diftrblo.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.rhopot0.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "rhopot0", "rhopot0", "access-om3.mom6.3d.rhopot0.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.rhopot2.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "rhopot2", "rhopot2", "access-om3.mom6.3d.rhopot2.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.thetao.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "thetao", "thetao", "access-om3.mom6.3d.thetao.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.so.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "so", "so", "access-om3.mom6.3d.so.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.T_adx.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "T_adx", "T_adx", "access-om3.mom6.3d.T_adx.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.T_ady.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "T_ady", "T_ady", "access-om3.mom6.3d.T_ady.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.S_adx.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "S_adx", "S_adx", "access-om3.mom6.3d.S_adx.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.S_ady.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "S_ady", "S_ady", "access-om3.mom6.3d.S_ady.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.T_diffx.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "T_diffx", "T_diffx", "access-om3.mom6.3d.T_diffx.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.T_diffy.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "T_diffy", "T_diffy", "access-om3.mom6.3d.T_diffy.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.S_diffx.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "S_diffx", "S_diffx", "access-om3.mom6.3d.S_diffx.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.S_diffy.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "S_diffy", "S_diffy", "access-om3.mom6.3d.S_diffy.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.umo.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "umo", "umo", "access-om3.mom6.3d.umo.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.vmo.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "vmo", "vmo", "access-om3.mom6.3d.vmo.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.uo.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "uo", "uo", "access-om3.mom6.3d.uo.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.vo.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "vo", "vo", "access-om3.mom6.3d.vo.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.uh.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "uh", "uh", "access-om3.mom6.3d.uh.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.vh.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "vh", "vh", "access-om3.mom6.3d.vh.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.uhGM.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "uhGM", "uhGM", "access-om3.mom6.3d.uhGM.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.vhGM.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "vhGM", "vhGM", "access-om3.mom6.3d.vhGM.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.uhml.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "uhml", "uhml", "access-om3.mom6.3d.uhml.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.vhml.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "vhml", "vhml", "access-om3.mom6.3d.vhml.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.thkcello.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "thkcello", "thkcello", "access-om3.mom6.3d.thkcello.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.KE.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "KE", "KE", "access-om3.mom6.3d.KE.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+
+# monthly 3d squared fields
+
+"access-om3.mom6.3d.uo.1mon.pow02.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "uo", "uo", "access-om3.mom6.3d.uo.1mon.pow02.%4yr%2mo", "all", "pow02", "none", 2
+
+"access-om3.mom6.3d.vo.1mon.pow02.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "vo", "vo", "access-om3.mom6.3d.vo.1mon.pow02.%4yr%2mo", "all", "pow02", "none", 2
+
+
+# monthly 2d fields
+
+"access-om3.mom6.2d.evs.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "evs", "evs", "access-om3.mom6.2d.evs.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.ficeberg.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "ficeberg", "ficeberg", "access-om3.mom6.2d.ficeberg.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.friver.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "friver", "friver", "access-om3.mom6.2d.friver.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.fsitherm.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "fsitherm", "fsitherm", "access-om3.mom6.2d.fsitherm.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.heat_content_cond.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "heat_content_cond", "heat_content_cond", "access-om3.mom6.2d.heat_content_cond.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.heat_content_evap.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "heat_content_evap", "heat_content_evap", "access-om3.mom6.2d.heat_content_evap.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.heat_content_fprec.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "heat_content_fprec", "heat_content_fprec", "access-om3.mom6.2d.heat_content_fprec.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.heat_content_frunoff.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "heat_content_frunoff", "heat_content_frunoff", "access-om3.mom6.2d.heat_content_frunoff.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.heat_content_lrunoff.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "heat_content_lrunoff", "heat_content_lrunoff", "access-om3.mom6.2d.heat_content_lrunoff.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.heat_content_lprec.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "heat_content_lprec", "heat_content_lprec", "access-om3.mom6.2d.heat_content_lprec.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.hfrunoffds.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "hfrunoffds", "hfrunoffds", "access-om3.mom6.2d.hfrunoffds.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.hfrainds.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "hfrainds", "hfrainds", "access-om3.mom6.2d.hfrainds.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.Heat_PmE.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "Heat_PmE", "Heat_PmE", "access-om3.mom6.2d.Heat_PmE.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.net_heat_coupler.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "net_heat_coupler", "net_heat_coupler", "access-om3.mom6.2d.net_heat_coupler.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.hfds.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "hfds", "hfds", "access-om3.mom6.2d.hfds.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.hflso.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "hflso", "hflso", "access-om3.mom6.2d.hflso.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.hfsifrazil.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "hfsifrazil", "hfsifrazil", "access-om3.mom6.2d.hfsifrazil.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.hfsnthermds.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "hfsnthermds", "hfsnthermds", "access-om3.mom6.2d.hfsnthermds.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.hfsso.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "hfsso", "hfsso", "access-om3.mom6.2d.hfsso.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.prlq.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "prlq", "prlq", "access-om3.mom6.2d.prlq.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.prsn.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "prsn", "prsn", "access-om3.mom6.2d.prsn.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.wfo.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "wfo", "wfo", "access-om3.mom6.2d.wfo.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.pso.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "pso", "pso", "access-om3.mom6.2d.pso.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.rlntds.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "rlntds", "rlntds", "access-om3.mom6.2d.rlntds.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.rsntds.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "rsntds", "rsntds", "access-om3.mom6.2d.rsntds.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.sfdsi.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "sfdsi", "sfdsi", "access-om3.mom6.2d.sfdsi.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.salt_flux_added.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "salt_flux_added", "salt_flux_added", "access-om3.mom6.2d.salt_flux_added.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.somint.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "somint", "somint", "access-om3.mom6.2d.somint.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.opottempmint.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "opottempmint", "opottempmint", "access-om3.mom6.2d.opottempmint.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.Rd_dx.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "Rd_dx", "Rd_dx", "access-om3.mom6.2d.Rd_dx.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.mass_wt.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "mass_wt", "mass_wt", "access-om3.mom6.2d.mass_wt.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.mlotst.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "mlotst", "mlotst", "access-om3.mom6.2d.mlotst.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.sos.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "sos", "sos", "access-om3.mom6.2d.sos.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.speed.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "speed", "speed", "access-om3.mom6.2d.speed.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.tos.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "tos", "tos", "access-om3.mom6.2d.tos.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.SSH.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "SSH", "SSH", "access-om3.mom6.2d.SSH.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.SSU.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "SSU", "SSU", "access-om3.mom6.2d.SSU.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.SSV.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "SSV", "SSV", "access-om3.mom6.2d.SSV.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.T_adx_2d.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "T_adx_2d", "T_adx_2d", "access-om3.mom6.2d.T_adx_2d.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.T_ady_2d.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "T_ady_2d", "T_ady_2d", "access-om3.mom6.2d.T_ady_2d.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.T_diffx_2d.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "T_diffx_2d", "T_diffx_2d", "access-om3.mom6.2d.T_diffx_2d.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.T_diffy_2d.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "T_diffy_2d", "T_diffy_2d", "access-om3.mom6.2d.T_diffy_2d.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.S_adx_2d.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "S_adx_2d", "S_adx_2d", "access-om3.mom6.2d.S_adx_2d.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.S_ady_2d.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "S_ady_2d", "S_ady_2d", "access-om3.mom6.2d.S_ady_2d.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.S_diffx_2d.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "S_diffx_2d", "S_diffx_2d", "access-om3.mom6.2d.S_diffx_2d.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.S_diffy_2d.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "S_diffy_2d", "S_diffy_2d", "access-om3.mom6.2d.S_diffy_2d.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.tauuo.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "tauuo", "tauuo", "access-om3.mom6.2d.tauuo.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.tauvo.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "tauvo", "tauvo", "access-om3.mom6.2d.tauvo.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.uhbt.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "uhbt", "uhbt", "access-om3.mom6.2d.uhbt.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.vhbt.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "vhbt", "vhbt", "access-om3.mom6.2d.vhbt.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.ustar.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "ustar", "ustar", "access-om3.mom6.2d.ustar.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.umo_2d.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "umo_2d", "umo_2d", "access-om3.mom6.2d.umo_2d.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.vmo_2d.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "vmo_2d", "vmo_2d", "access-om3.mom6.2d.vmo_2d.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.pbo.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "pbo", "pbo", "access-om3.mom6.2d.pbo.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.SW_pen.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "SW_pen", "SW_pen", "access-om3.mom6.2d.SW_pen.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.salt_flux_in.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "salt_flux_in", "salt_flux_in", "access-om3.mom6.2d.salt_flux_in.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.tnkebto.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "tnkebto", "tnkebto", "access-om3.mom6.2d.tnkebto.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+
+# monthly 2d max fields
+
+"access-om3.mom6.2d.mlotst.1mon.max.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "mlotst", "mlotst", "access-om3.mom6.2d.mlotst.1mon.max.%4yr%2mo", "all", "max", "none", 2
+
+"access-om3.mom6.2d.sos.1mon.max.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "sos", "sos", "access-om3.mom6.2d.sos.1mon.max.%4yr%2mo", "all", "max", "none", 2
+
+"access-om3.mom6.2d.tos.1mon.max.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "tos", "tos", "access-om3.mom6.2d.tos.1mon.max.%4yr%2mo", "all", "max", "none", 2
+
+"access-om3.mom6.2d.SSH.1mon.max.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "SSH", "SSH", "access-om3.mom6.2d.SSH.1mon.max.%4yr%2mo", "all", "max", "none", 2
+
+
+# monthly 2d min fields
+
+"access-om3.mom6.2d.mlotst.1mon.min.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "mlotst", "mlotst", "access-om3.mom6.2d.mlotst.1mon.min.%4yr%2mo", "all", "min", "none", 2
+
+"access-om3.mom6.2d.sos.1mon.min.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "sos", "sos", "access-om3.mom6.2d.sos.1mon.min.%4yr%2mo", "all", "min", "none", 2
+
+"access-om3.mom6.2d.tos.1mon.min.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "tos", "tos", "access-om3.mom6.2d.tos.1mon.min.%4yr%2mo", "all", "min", "none", 2
+
+"access-om3.mom6.2d.SSH.1mon.min.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"ocean_model", "SSH", "SSH", "access-om3.mom6.2d.SSH.1mon.min.%4yr%2mo", "all", "min", "none", 2
+
+
+# daily 2D fields
+
+"access-om3.mom6.2d.tob.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 1, "months"
+"ocean_model", "tob", "tob", "access-om3.mom6.2d.tob.1day.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.mlotst.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 1, "months"
+"ocean_model", "mlotst", "mlotst", "access-om3.mom6.2d.mlotst.1day.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.e_D.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 1, "months"
+"ocean_model", "e_D", "e_D", "access-om3.mom6.2d.e_D.1day.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.net_heat_coupler.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 1, "months"
+"ocean_model", "net_heat_coupler", "net_heat_coupler", "access-om3.mom6.2d.net_heat_coupler.1day.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.heat_content_lrunoff.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 1, "months"
+"ocean_model", "heat_content_lrunoff", "heat_content_lrunoff", "access-om3.mom6.2d.heat_content_lrunoff.1day.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.Heat_PmE.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 1, "months"
+"ocean_model", "Heat_PmE", "Heat_PmE", "access-om3.mom6.2d.Heat_PmE.1day.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.tos.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 1, "months"
+"ocean_model", "tos", "tos", "access-om3.mom6.2d.tos.1day.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.sos.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 1, "months"
+"ocean_model", "sos", "sos", "access-om3.mom6.2d.sos.1day.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.SSU.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 1, "months"
+"ocean_model", "SSU", "SSU", "access-om3.mom6.2d.SSU.1day.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.SSV.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 1, "months"
+"ocean_model", "SSV", "SSV", "access-om3.mom6.2d.SSV.1day.mean.%4yr%2mo", "all", "average", "none", 2
+
+
+# daily 2D max fields
+
+"access-om3.mom6.2d.e_D.1day.max.%4yr%2mo", 1, "days", 1, "days", "time", 1, "months"
+"ocean_model", "e_D", "e_D", "access-om3.mom6.2d.e_D.1day.max.%4yr%2mo", "all", "max", "none", 2
+
+"access-om3.mom6.2d.tos.1day.max.%4yr%2mo", 1, "days", 1, "days", "time", 1, "months"
+"ocean_model", "tos", "tos", "access-om3.mom6.2d.tos.1day.max.%4yr%2mo", "all", "max", "none", 2
+
+
+# daily 2D min fields
+
+"access-om3.mom6.2d.tos.1day.min.%4yr%2mo", 1, "days", 1, "days", "time", 1, "months"
+"ocean_model", "tos", "tos", "access-om3.mom6.2d.tos.1day.min.%4yr%2mo", "all", "min", "none", 2
+
+
+# daily scalar timeseries
+
+"access-om3.mom6.scalar.1day.snap.%4yr%2mo", 1, "days", 1, "days", "time", 1, "months"
+"ocean_model", "soga", "soga", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "thetaoga", "thetaoga", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "tosga", "tosga", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "sosga", "sosga", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_salt_Flux_Added", "total_salt_Flux_Added", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_salt_Flux_In", "total_salt_Flux_In", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_salt_flux", "total_salt_flux", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "net_fresh_water_global_adjustment", "net_fresh_water_global_adjustment", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "salt_flux_global_restoring_adjustment", "salt_flux_global_restoring_adjustment", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_wfo", "total_wfo", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_evs", "total_evs", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_fsitherm", "total_fsitherm", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_precip", "total_precip", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_prsn", "total_prsn", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_lprec", "total_lprec", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_ficeberg", "total_ficeberg", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_friver", "total_friver", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_net_massout", "total_net_massout", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_net_massin", "total_net_massin", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+
+
+# monthly 3d BGC fields
+
+"access-om3.mom6.3d.radbio3d.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "radbio3d", "radbio3d", "access-om3.mom6.3d.radbio3d.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.npp3d.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "npp3d", "npp3d", "access-om3.mom6.3d.npp3d.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.pprod_gross.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "pprod_gross", "pprod_gross", "access-om3.mom6.3d.pprod_gross.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.zprod_gross.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "zprod_gross", "zprod_gross", "access-om3.mom6.3d.zprod_gross.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.no3.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "no3", "no3", "access-om3.mom6.3d.no3.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.phy.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "phy", "phy", "access-om3.mom6.3d.phy.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.o2.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "o2", "o2", "access-om3.mom6.3d.o2.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.zoo.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "zoo", "zoo", "access-om3.mom6.3d.zoo.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.det.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "det", "det", "access-om3.mom6.3d.det.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.caco3.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "caco3", "caco3", "access-om3.mom6.3d.caco3.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.adic.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "adic", "adic", "access-om3.mom6.3d.adic.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.dic.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "dic", "dic", "access-om3.mom6.3d.dic.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.alk.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "alk", "alk", "access-om3.mom6.3d.alk.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.fe.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "fe", "fe", "access-om3.mom6.3d.fe.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.det_sediment.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "det_sediment", "det_sediment", "access-om3.mom6.3d.det_sediment.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.3d.caco3_sediment.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "caco3_sediment", "caco3_sediment", "access-om3.mom6.3d.caco3_sediment.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+
+# monthly 2d BGC fields
+
+"access-om3.mom6.2d.pco2.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "pco2", "pco2", "access-om3.mom6.2d.pco2.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.paco2.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "paco2", "paco2", "access-om3.mom6.2d.paco2.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.light_limit.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "light_limit", "light_limit", "access-om3.mom6.2d.light_limit.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.radbio1.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "radbio1", "radbio1", "access-om3.mom6.2d.radbio1.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.det_sed_remin.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "det_sed_remin", "det_sed_remin", "access-om3.mom6.2d.det_sed_remin.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.det_sed_depst.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "det_sed_depst", "det_sed_depst", "access-om3.mom6.2d.det_sed_depst.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.caco3_sed_remin.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "caco3_sed_remin", "caco3_sed_remin", "access-om3.mom6.2d.caco3_sed_remin.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.caco3_sed_depst.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "caco3_sed_depst", "caco3_sed_depst", "access-om3.mom6.2d.caco3_sed_depst.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.wdet100.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "wdet100", "wdet100", "access-om3.mom6.2d.wdet100.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.npp2d.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "npp2d", "npp2d", "access-om3.mom6.2d.npp2d.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.npp1.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "npp1", "npp1", "access-om3.mom6.2d.npp1.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.pprod_gross_2d.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "pprod_gross_2d", "pprod_gross_2d", "access-om3.mom6.2d.pprod_gross_2d.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.dic_intmld.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "dic_intmld", "dic_intmld", "access-om3.mom6.2d.dic_intmld.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.adic_intmld.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "adic_intmld", "adic_intmld", "access-om3.mom6.2d.adic_intmld.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.o2_intmld.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "o2_intmld", "o2_intmld", "access-om3.mom6.2d.o2_intmld.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.no3_intmld.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "no3_intmld", "no3_intmld", "access-om3.mom6.2d.no3_intmld.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.fe_intmld.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "fe_intmld", "fe_intmld", "access-om3.mom6.2d.fe_intmld.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.phy_intmld.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "phy_intmld", "phy_intmld", "access-om3.mom6.2d.phy_intmld.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.det_intmld.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "det_intmld", "det_intmld", "access-om3.mom6.2d.det_intmld.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.pprod_gross_intmld.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "pprod_gross_intmld", "pprod_gross_intmld", "access-om3.mom6.2d.pprod_gross_intmld.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.npp_intmld.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "npp_intmld", "npp_intmld", "access-om3.mom6.2d.npp_intmld.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.radbio_intmld.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "radbio_intmld", "radbio_intmld", "access-om3.mom6.2d.radbio_intmld.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.dic_int100.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "dic_int100", "dic_int100", "access-om3.mom6.2d.dic_int100.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.adic_int100.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "adic_int100", "adic_int100", "access-om3.mom6.2d.adic_int100.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.o2_int100.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "o2_int100", "o2_int100", "access-om3.mom6.2d.o2_int100.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.no3_int100.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "no3_int100", "no3_int100", "access-om3.mom6.2d.no3_int100.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.fe_int100.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "fe_int100", "fe_int100", "access-om3.mom6.2d.fe_int100.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.phy_int100.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "phy_int100", "phy_int100", "access-om3.mom6.2d.phy_int100.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.det_int100.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "det_int100", "det_int100", "access-om3.mom6.2d.det_int100.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.pprod_gross_int100.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "pprod_gross_int100", "pprod_gross_int100", "access-om3.mom6.2d.pprod_gross_int100.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.npp_int100.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "npp_int100", "npp_int100", "access-om3.mom6.2d.npp_int100.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.radbio_int100.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "radbio_int100", "radbio_int100", "access-om3.mom6.2d.radbio_int100.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.no3_stf.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "no3_stf", "no3_stf", "access-om3.mom6.2d.no3_stf.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.no3_vstf.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "no3_vstf", "no3_vstf", "access-om3.mom6.2d.no3_vstf.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.no3_btf.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "no3_btf", "no3_btf", "access-om3.mom6.2d.no3_btf.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.phy_stf.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "phy_stf", "phy_stf", "access-om3.mom6.2d.phy_stf.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.phy_trunoff.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "phy_trunoff", "phy_trunoff", "access-om3.mom6.2d.phy_trunoff.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.o2_stf.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "o2_stf", "o2_stf", "access-om3.mom6.2d.o2_stf.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.o2_stf_gas.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "o2_stf_gas", "o2_stf_gas", "access-om3.mom6.2d.o2_stf_gas.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.o2_btf.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "o2_btf", "o2_btf", "access-om3.mom6.2d.o2_btf.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.o2_alpha.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "o2_alpha", "o2_alpha", "access-om3.mom6.2d.o2_alpha.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.o2_csurf.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "o2_csurf", "o2_csurf", "access-om3.mom6.2d.o2_csurf.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.o2_sc_no.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "o2_sc_no", "o2_sc_no", "access-om3.mom6.2d.o2_sc_no.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.adic_stf.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "adic_stf", "adic_stf", "access-om3.mom6.2d.adic_stf.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.adic_stf_gas.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "adic_stf_gas", "adic_stf_gas", "access-om3.mom6.2d.adic_stf_gas.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.adic_vstf.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "adic_vstf", "adic_vstf", "access-om3.mom6.2d.adic_vstf.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.alk_vstf.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "alk_vstf", "alk_vstf", "access-om3.mom6.2d.alk_vstf.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.adic_btf.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "adic_btf", "adic_btf", "access-om3.mom6.2d.adic_btf.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.adic_alpha.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "adic_alpha", "adic_alpha", "access-om3.mom6.2d.adic_alpha.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.adic_csurf.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "adic_csurf", "adic_csurf", "access-om3.mom6.2d.adic_csurf.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.adic_sc_no.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "adic_sc_no", "adic_sc_no", "access-om3.mom6.2d.adic_sc_no.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.dic_stf.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "dic_stf", "dic_stf", "access-om3.mom6.2d.dic_stf.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.dic_stf_gas.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "dic_stf_gas", "dic_stf_gas", "access-om3.mom6.2d.dic_stf_gas.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.dic_vstf.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "dic_vstf", "dic_vstf", "access-om3.mom6.2d.dic_vstf.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.dic_btf.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "dic_btf", "dic_btf", "access-om3.mom6.2d.dic_btf.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.dic_alpha.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "dic_alpha", "dic_alpha", "access-om3.mom6.2d.dic_alpha.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.dic_csurf.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "dic_csurf", "dic_csurf", "access-om3.mom6.2d.dic_csurf.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.dic_sc_no.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "dic_sc_no", "dic_sc_no", "access-om3.mom6.2d.dic_sc_no.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.alk_stf.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "alk_stf", "alk_stf", "access-om3.mom6.2d.alk_stf.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.alk_btf.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "alk_btf", "alk_btf", "access-om3.mom6.2d.alk_btf.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.fe_stf.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "fe_stf", "fe_stf", "access-om3.mom6.2d.fe_stf.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+
+"access-om3.mom6.2d.fe_btf.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
+"generic_wombatlite", "fe_btf", "fe_btf", "access-om3.mom6.2d.fe_btf.1mon.mean.%4yr%2mo", "all", "average", "none", 2

--- a/diag_table_source.yaml
+++ b/diag_table_source.yaml
@@ -1,0 +1,469 @@
+#######################################################################################################
+# This yaml file is used by make_diag_table.py to create a diag_table file specifying MOM5 diagnostics.
+# Latest version: https://github.com/COSIMA/make_diag_table
+#
+# Define the diagnostics you want in the diag_table section below.
+#
+# The MOM diag_table format is defined here:
+# https://github.com/mom-ocean/MOM5/blob/master/src/shared/diag_manager/diag_table.F90
+# https://mom6.readthedocs.io/en/main/api/generated/pages/Diagnostics.html
+#######################################################################################################
+
+
+# Define global default settings which will be applied to all diagnostics,
+# unless overridden in diag_table section below, either in defaults or individual fields.
+# You're unlikely to need to change any of the global_defaults.
+global_defaults:
+# global_section:
+    title: ACCESS-OM3  # any string
+    base_date: [ 1900, 1, 1, 0, 0, 0 ]  # reference time used for the time units. six integers: year, month, day, hour, minute, second
+# file section:
+    file_name:  # String, or list of components, for file name (without trailing ".nc").
+    # If a list, its elements are a mixture of strings and dictionaries.
+    # String list elements are concatenated, each preceded by file_name_separator.
+    # Dictionary list elements must have one key-value pair; the value is a list
+    # containing 1 or more strings to be concatenated, each preceded by the key
+    # (a string) instead of file_name_separator. The key may be an empty string,
+    # which is useful if file_name_date begins with %, since FMS prepends _ .
+    # All filename list string elements (other than field_name) must exist as keys in global_defaults.
+    # If file_name_date is used, it must be the last item.
+    # Key values are looked up, converted to strings and then substituted using file_name_substitutions.
+    # Empty strings (and their preceding separator) are ignored if file_name_omit_empty is true.
+    # A separator is not used prior to the first item.
+        - file_name_prefix
+        - file_name_dimension
+        - field_name  # substituted by field name in diag_table section below
+        - output_freq
+        - '':
+            - output_freq_units
+        - reduction_method
+        - file_name_date
+    output_freq: 1  # integer: output sampling frequency in output_freq_units (0: every timestep; -1: only at end of run)
+    output_freq_units: months  # time units for output: years, months, days, hours, minutes, or seconds
+    file_format: 1  # integer, must be 1, specifying NetCDF (the only format currently supported)
+    time_axis_units: days  # time units for the output file time axis: years, months, days, hours, minutes, or seconds
+    time_axis_name: time  # must be "time" (case-insensitive)
+    new_file_freq: 1  # optional integer: frequency (in new_file_freq_units) for closing the existing file, and creating a new file
+    new_file_freq_units: months  # time units for new_file_freq: years, months, days, hours, minutes, or seconds (optional; required if and only if new_file_freq specified)
+    start_time:  # Time to start the file for the first time. The format of this string is the same as base_date (optional; requires new_file_freq, new_file_freq_units)
+    file_duration:  # integer: How long file should receive data after start time (optional; requires new_file_freq, new_file_freq_units, start_time)
+    file_duration_units:  # units for file_duration: years, months, days, hours, minutes, or seconds (optional; required if and only if file_duration specified)
+# field section:
+    module_name: ocean_model
+    field_name:  # set via keys in the fields section of the diag_table section below
+    output_name:  # same as field_name unless overridden
+    # file_name:  # same as file_name in file section above unless overridden in diag_table section below
+    time_sampling: all  # Currently not used.  Please use the string "all".
+    reduction_method: snap  # mean, snap, rms, pow##, min, max, or diurnal##
+    # reduction_method options:
+    #     mean or average or true: Average from the last time written to the current time. Becomes "average" in diag_table.
+    #     snap or none or false: No reduction.  Write snapshot of current time step value only. Becomes "none" in diag_table.
+    #     rms: Calculate the root mean square from the last time written to the current time.
+    #     pow##: Calculate the mean of the power ## from the last time written to the current time.
+    #     min: Minimum value from last write to current time.
+    #     max: Maximum value from last write to current time.
+    #     diurnal##: ## diurnal averages
+    regional_section: none  # string: bounds of the regional section to capture ("none" indicates a global region). String format: lat_min, lat_max, lon_min, lon_max, vert_min, vert_max. Use vert_min = -1 and vert_max = -1 to get the entire vertical axis.
+    packing: 2
+    # packing is the Fortran number KIND of the data written:
+    #     1: double precision
+    #     2: float (single precision)
+    #     4: packed 16-bit integers
+    #     8: packed 1-byte (not tested)
+# extra things for constructing filename:
+    file_name_dimension: 3d  # descriptor for filename, e.g. 3d, 2d, scalar
+    file_name_prefix: access-om3.mom6
+    file_name_date: "%4yr%2mo"  # "%4yr%2mo" # run date/time of file opening; format: %, 1 digit (#digits), one of (yr, mo, dy, hr, mi, sc); date/time components will be separated by _ in filename.
+    file_name_separator: "."  # used to separate filename components; best not to use "_" to avoid confusion with fields and dates
+    file_name_omit_empty: true  # whether to omit empty filename components to avoid duplicate file_name_separator
+    file_name_substitutions:  # string replacements for filename components
+        years: yr
+        months: mon
+        days: day
+        hours: hr
+        none: snap  # careful! will apply to both reduction_method and regional_section
+        'False': snap
+        average: mean
+        'True': mean
+        None: ""  # for empty items
+# %yr, %mo, %dy, %hr %mi, %sc are expanded to the current year, month, day, hour, minute and second respectively,
+
+#######################################################################################################
+# diag_table section - this defines the diagnostics that will appear in diag_table.
+# 
+# Top-level categories in diag_table have arbitrary names (they're just used for
+# comments in the output diag_table). Make as many of these as you like to group
+# similar diagnostics with shared defaults. Note that each of the top-level
+# categories can have only have one instance of each field name, so if you need
+# multiple outputs of the same field (e.g. as both averages and snapshots), you’ll
+# need to make additional categories.
+# 
+# Within each top-level category there's an optional defaults section and a
+# fields section. The defaults section overrides items in global_defaults for
+# all fields in the category. The field section specifies diagnostic field
+# names. To add a new diagnostic, all you need to do is add its name to the
+# field section in the appropriate category. Each field name can be followed by
+# a dictionary overriding the category and global defaults for that field only.
+# 
+# Some of the available diagnostics are listed here:
+# https://raw.githubusercontent.com/COSIMA/access-om2/master/MOM_diags.txt
+# https://github.com/COSIMA/access-om2/wiki/Technical-documentation#MOM5-diagnostics-list
+diag_table:
+    'static 2d grid data':
+        defaults:  # these can be overridden for individual fields below
+            file_name_dimension: static  # descriptor for filename, e.g. 3d, 2d, scalar
+            file_name:  # String, or list of components, for file name (without trailing ".nc").
+            # If a list, its elements are a mixture of strings and dictionaries.
+            # String list elements are concatenated, each preceded by file_name_separator.
+            # Dictionary list elements must have one key-value pair; the value is a list
+            # containing 1 or more strings to be concatenated, each preceded by the key
+            # (a string) instead of file_name_separator. The key may be an empty string,
+            # which is useful if file_name_date begins with %, since FMS prepends _ .
+            # All filename list string elements (other than field_name) must exist as keys in global_defaults.
+            # If file_name_date is used, it must be the last item.
+            # Key values are looked up, converted to strings and then substituted using file_name_substitutions.
+            # Empty strings (and their preceding separator) are ignored if file_name_omit_empty is true.
+            # A separator is not used prior to the first item.
+                - file_name_prefix
+                - file_name_dimension
+            packing: 1 # double precision
+            reduction_method: snap  # mean, snap, rms, pow##, min, max, or diurnal##
+            output_freq: -1  # Output frequency in output_freq_units (0: every timestep; -1: only at end of run)
+            output_freq_units: months  # time units for output: years, months, days, hours, minutes, or seconds
+            new_file_freq:  # optional integer: frequency (in new_file_freq_units) for closing the existing file, and creating a new file
+        fields:
+            areacello: # Surface area of tracer (T) cells
+            areacello_cu: # Surface area of x-direction flow (U) cells
+            areacello_cv: # Surface area of y-direction flow (V) cells
+            areacello_bu: # Surface area of B-grid flow (Q) cells
+            dxt: # Delta(x) at thickness/tracer points (meter)
+            dyt: # Delta(y) at thickness/tracer points (meter)
+            geolat_c: # Latitude of corner (Bu) points
+            geolat: # Latitude of tracer (T) points
+            geolat_u: # Latitude of zonal velocity (Cu) points
+            geolat_v: # Latitude of meridional velocity (Cv) points
+            geolon_c: # Longitude of corner (Bu) points
+            geolon: # Longitude of tracer (T) points
+            geolon_u: # Longitude of zonal velocity (Cu) points
+            geolon_v: # Longitude of meridional velocity (Cv) points
+            deptho: # Depth of the ocean at tracer points
+            wet: # 0 if land, 1 if ocean at tracer points
+            wet_c: # 0 if land, 1 if ocean at corner (Bu) points
+            wet_u: # 0 if land, 1 if ocean at zonal velocity (Cu) points
+            wet_v: # 0 if land, 1 if ocean at meridional velocity (Cv) points
+            Coriolis: # Coriolis parameter at corner (Bu) points
+            sin_rot: # sine of the clockwise angle of the ocean grid north to true north
+            cos_rot: # cosine of the clockwise angle of the ocean grid north to true north
+            dxCu: # dxCu is delta x at u points [L ~> m]
+            dyCu: # dyCu is delta y at u points [L ~> m]
+            dxCv: # dxCv is delta x at v points [L ~> m]
+            dyCv: # dyCv is delta y at v points [L ~> m]
+            dyCuo: # Open meridional grid spacing at u points (meter)
+            dxCvo: # Open zonal grid spacing at v points (meter)
+    'monthly 3d fields':
+        defaults:  # these can be overridden for individual fields below
+            file_name_dimension: 3d  # descriptor for filename, e.g. 3d, 2d, scalar
+            reduction_method: mean
+        fields:
+            h: # Layer Thickness
+            e: # Interface Height Relative to Mean Sea Level
+            agessc: # Sea water age since surface contact
+            difmxybo: # Biharmonic Horizontal Viscosity at h Points Ahh
+            difmxylo: # Laplacian Horizontal Viscosity at h Points Khh
+            diftrelo: # Epipycnal tracer diffusivity at tracer cell center KHTR_h
+            diftrblo: # Ocean Tracer Diffusivity due to Parameterized Mesoscale Advection KHTH_t
+            rhopot0: # Potential density referenced to surface
+            rhopot2: # Potential density referenced to 2000 dbar
+            thetao: # Potential Temperature
+            so: # Salinity
+            T_adx: # Temperature x flux (advection)
+            T_ady: # Temperature y flux (advection)
+            S_adx: # Salinity x flux (advection)
+            S_ady: # Salinity y flux (advection)
+            T_diffx: # Diffusive Zonal Flux of temperature
+            T_diffy: # Diffusive Meridional Flux of temperature
+            S_diffx: # Diffusive Zonal Flux of salinity
+            S_diffy: # Diffusive Meridional Flux of salinity
+            umo: # Ocean Mass X Transport
+            vmo: # Ocean Mass Y Transport
+            uo: # u velocity
+            vo: # v velocity
+            uh: # Zonal Thickness Flux
+            vh: # Meridional Thickness Flux
+            uhGM: # Time Mean Diffusive Zonal Thickness Flux
+            vhGM: # Time Mean Diffusive Meridional Thickness Flux
+            uhml: # Zonal Thickness Flux to Restratify Mixed Layer
+            vhml: # Meridional Thickness Flux to Restratify Mixed Layer
+            thkcello: # Cell Thickness
+            KE: # Layer Kinetic energy per unit mass
+
+    'monthly 3d squared fields':  # for calculating EKE etc
+        defaults:  # these can be overridden for individual fields below
+            file_name_dimension: 3d  # descriptor for filename, e.g. 3d, 2d, scalar
+            reduction_method: pow02  # mean, snap, rms, pow##, min, max, or diurnal##
+        fields:
+            uo:
+            vo:
+            
+    'monthly 2d fields':
+        defaults:  # these can be overridden for individual fields below
+            file_name_dimension: 2d  # descriptor for filename, e.g. 3d, 2d, scalar
+            reduction_method: mean
+        fields:
+            evs: # Evaporation/condensation at ocean surface (evaporation is negative) evap
+            ficeberg: # Frozen runoff (calving) and iceberg melt into ocean frunoff
+            friver: # Liquid runoff (rivers) into ocean lrunoff
+            fsitherm: # water flux to ocean from snow/sea ice melting(> 0) or formation(< 0) seaice_melt
+            heat_content_cond: # Heat content (relative to 0degC) of water condensing into ocean
+            heat_content_evap: # Heat content (relative to 0degC) of water evaporating from ocean
+            heat_content_fprec: # Heat content (relative to 0degC) of frozen prec entering ocean
+            heat_content_frunoff: # Heat content (relative to 0C) of solid runoff into ocean
+            heat_content_lrunoff: # Heat content (relative to 0C) of liquid runoff into ocean
+            heat_content_lprec: # Heat content (relative to 0degC) of liquid precip entering ocean
+            hfrunoffds: # Heat content (relative to 0C) of liquid+solid runoff into ocean
+            hfrainds: # Heat content (relative to 0degC) of liquid+frozen precip entering ocean
+            Heat_PmE: # Heat flux into ocean from mass flux into ocean
+            net_heat_coupler: # Surface ocean heat flux from SW+LW+latent+sensible+seaice_melt_heat (via the coupler)
+            hfds: # Surface ocean heat flux from SW+LW+lat+sens+mass transfer+frazil+restore+seaice_melt_heat or flux adjustments net_heat_surface
+            hflso: # Latent heat flux into ocean due to fusion and evaporation (negative means ocean heat loss)
+            hfsifrazil: # Heat from frazil formation frazil
+            hfsnthermds: # Latent heat flux into ocean due to melting of frozen precipitation latent_fprec_diag
+            hfsso: # Sensible heat flux into ocean sensible
+            prlq: # Liquid precipitation into ocean lprec
+            prsn: # Frozen precipitation into ocean fprec
+            wfo: # Net surface water flux (precip+melt+lrunoff+ice calving-evap) PRCmE
+            pso: # Pressure at ice-ocean or atmosphere-ocean interface p_surf
+            rlntds: # surface_net_downward_longwave_flux LW
+            rsntds: # Shortwave radiation flux into ocean
+            sfdsi: # Net salt flux into ocean at surface (restoring + sea-ice) salt_flux
+            salt_flux_added: # Salt flux into ocean at surface due to restoring or flux adjustment
+            somint: # Density weighted column integrated salinity salt_int
+            opottempmint: # Density weighted column integrated potential temperature  temp_int
+            Rd_dx: # Ratio between deformation radius and grid spacing
+            mass_wt: # The column mass for calculating mass-weighted average properties
+            mlotst: # Mixed layer depth (delta rho = 0.03) MLD_003
+            #oml: # Thickness of the surface Ocean Boundary Layer without smoothing calculated by [CVMix] KPP KPP_OBLdepth_original
+            sos: # Sea Surface Salinity
+            speed: # Sea Surface Speed
+            tos: # Sea Surface Temperature
+            SSH: # Sea Surface Height
+            SSU: # Sea Surface Zonal Velocity
+            SSV: # Sea Surface Meridional Velocity
+            T_adx_2d: # Vertically Integrated Advective Zonal Flux of Heat
+            T_ady_2d: # Vertically Integrated Advective Meridional Flux of Heat
+            T_diffx_2d: # Vertically Integrated Diffusive Zonal Flux of Heat
+            T_diffy_2d: # Vertically Integrated Diffusive Meridional Flux of Heat    
+            S_adx_2d: # Vertically Integrated Advective Zonal Flux of Salinity
+            S_ady_2d: # Vertically Integrated Advective Meridional Flux of Salinity
+            S_diffx_2d: # Vertically Integrated Diffusive Zonal Flux of Salinity
+            S_diffy_2d: # Vertically Integrated Diffusive Meridional Flux of Salinity
+            tauuo: # surface_downward_x_stress taux
+            tauvo: # surface_downward_y_stress tauy
+            uhbt: # Barotropic zonal transport averaged over a baroclinic step
+            vhbt: # Barotropic meridional transport averaged over a baroclinic step
+            ustar: # Surface friction velocity = [(gustiness + tau_magnitude)/rho0]^(1/2)
+            umo_2d: # Ocean Mass X Transport Vertical Sum
+            vmo_2d: # Ocean Mass Y Transport Vertical Sum
+            pbo: # Sea Water Pressure at Sea Floor
+            SW_pen: # Penetrating shortwave radiation flux into ocean W m-2
+            salt_flux_in: # Salt flux into ocean at surface from coupler
+            tnkebto: # Integrated Tendency of Ocean Mesoscale Eddy KE from Parameterized Eddy Advection GMwork
+
+    'monthly 2d max fields':
+        defaults:  # these can be overridden for individual fields below
+            file_name_dimension: 2d  # descriptor for filename, e.g. 3d, 2d, scalar
+            reduction_method: max  # mean, snap, rms, pow##, min, max, or diurnal##
+        fields:
+            mlotst: # Mixed layer depth (delta rho = 0.03) MLD_003
+            sos: # Sea Surface Salinity
+            tos: # Sea Surface Temperature
+            SSH: # Sea Surface Height
+
+    'monthly 2d min fields':
+        defaults:  # these can be overridden for individual fields below
+            file_name_dimension: 2d  # descriptor for filename, e.g. 3d, 2d, scalar
+            reduction_method: min  # mean, snap, rms, pow##, min, max, or diurnal##
+        fields:
+            mlotst: # Mixed layer depth (delta rho = 0.03) MLD_003
+            sos: # Sea Surface Salinity
+            tos: # Sea Surface Temperature
+            SSH: # Sea Surface Height
+
+    'daily 2D fields':
+        defaults:
+            file_name_dimension: 2d  # descriptor for filename, e.g. 3d, 2d, scalar
+            '':
+                - output_freq_units
+            output_freq_units: days  # time units for output: years, months, days, hours, minutes, or seconds
+            reduction_method: mean # mean, snap, rms, pow##, min, max, or diurnal##
+        fields:
+            tob: # Sea Water Potential Temperature at Sea Floor
+            mlotst: # Mixed layer depth (delta rho = 0.03) MLD_003
+            e_D: # Interface Height above the Seafloor (m)
+            net_heat_coupler: # Surface ocean heat flux from SW+LW+latent+sensible+seaice_melt_heat (via the coupler)
+            heat_content_lrunoff: # Heat content (relative to 0C) of liquid runoff into ocean
+            Heat_PmE: # Heat flux into ocean from mass flux into ocean
+            tos: # Sea Surface Temperature
+            sos: # Sea Surface Salinity
+            SSU: # Sea Surface Zonal Velocity
+            SSV: # Sea Surface Meridional Velocity
+
+    'daily 2D max fields':
+        defaults:
+            file_name_dimension: 2d  # descriptor for filename, e.g. 3d, 2d, scalar
+            '':
+                - output_freq_units
+            output_freq_units: days  # time units for output: years, months, days, hours, minutes, or seconds
+            reduction_method: max # mean, snap, rms, pow##, min, max, or diurnal##
+        fields:
+            e_D: # Interface Height above the Seafloor (m)
+            tos: # Sea Surface Temperature
+
+    'daily 2D min fields':
+        defaults:
+            file_name_dimension: 2d  # descriptor for filename, e.g. 3d, 2d, scalar
+            '':
+                - output_freq_units
+            output_freq_units: days  # time units for output: years, months, days, hours, minutes, or seconds
+            reduction_method: min # mean, snap, rms, pow##, min, max, or diurnal##
+        fields:
+            tos: # Sea Surface Temperature
+
+    'daily scalar timeseries':
+        defaults:  # these can be overridden for individual fields below
+            file_name_dimension: scalar  # descriptor for filename, e.g. 3d, 2d, scalar
+            file_name:  # String, or list of components, for file name (without trailing ".nc").
+            # If a list, its elements are a mixture of strings and dictionaries.
+            # String list elements are concatenated, each preceded by file_name_separator.
+            # Dictionary list elements must have one key-value pair; the value is a list
+            # containing 1 or more strings to be concatenated, each preceded by the key
+            # (a string) instead of file_name_separator. The key may be an empty string,
+            # which is useful if file_name_date begins with %, since FMS prepends _ .
+            # All filename list string elements (other than field_name) must exist as keys in global_defaults.
+            # If file_name_date is used, it must be the last item.
+            # Key values are looked up, converted to strings and then substituted using file_name_substitutions.
+            # Empty strings (and their preceding separator) are ignored if file_name_omit_empty is true.
+            # A separator is not used prior to the first item.
+                - file_name_prefix
+                - file_name_dimension
+                - output_freq
+                - '':
+                    - output_freq_units
+                - reduction_method
+                - file_name_date
+            output_freq_units: days  # time units for output: years, months, days, hours, minutes, or seconds
+            reduction_method: snap  # mean, snap, rms, pow##, min, max, or diurnal##
+            packing: 1  # double precision
+        fields:
+            soga: # Global Mean Ocean Salinity
+            thetaoga: # Global Mean Ocean Potential Temperature
+            tosga: # Global Area Average Sea Surface Temperature sst_global
+            sosga: # Global Area Average Sea Surface Salinity sss_global
+            total_salt_Flux_Added: # Area integrated surface salt flux due to restoring or flux adjustment 
+            total_salt_Flux_In: # Area integrated surface salt flux at surface from coupler
+            total_salt_flux: # Area integrated surface salt flux
+            net_fresh_water_global_adjustment: # Adjustment needed to adjust net fresh water into ocean to zero
+            salt_flux_global_restoring_adjustment: # Adjustment needed to balance net global salt flux into ocean at surface
+            total_wfo: # Area integrated net surface water flux (precip+melt+liq runoff+ice calving-evap) total_PRCmE
+            total_evs: # Area integrated evap/condense at ocean surface total_evap
+            total_fsitherm: # Area integrated sea ice melt (>0) or form (<0) total_icemelt
+            total_precip: # Area integrated liquid+frozen precip into ocean
+            total_prsn: # Area integrated frozen precip into ocean total_fprec
+            total_lprec: # Area integrated liquid precip into ocean
+            total_ficeberg: # Area integrated frozen runoff (calving) & iceberg melt into ocean total_frunoff
+            total_friver: # Area integrated liquid runoff into ocean total_lrunoff
+            total_net_massout: # Area integrated mass leaving ocean due to evap and seaice form
+            total_net_massin: # Area integrated mass entering ocean due to predip, runoff, ice melt
+
+    'monthly 3d BGC fields':
+        defaults:  # these can be overridden for individual fields below
+            file_name_dimension: 3d  # descriptor for filename, e.g. 3d, 2d, scalar
+            reduction_method: mean
+            module_name: generic_wombatlite
+        fields:
+            radbio3d: # Photosynthetically active radiation for phytoplankton growth (W m-2)
+            npp3d: # Net primary productivity (mol/kg/s)
+            pprod_gross: # Gross phytoplankton production (mol/kg/s)
+            zprod_gross: # Gross zooplankton production (mol/kg/s)
+            no3: # Nitrate (mol/kg)
+            phy: # Phytoplankton (mol/kg)
+            o2: # Oxygen (mol/kg)
+            zoo: # Zooplankton (mol/kg)
+            det: # Detritus (mol/kg)
+            caco3: # CaCO3 (mol/kg)
+            adic: # Natural + anthropogenic Dissolved Inorganic Carbon (mol/kg)
+            dic: # Natural Dissolved Inorganic Carbon (mol/kg)
+            alk: # Alkalinity (mol/kg)
+            fe: # Dissolved Iron (mol/kg)
+            det_sediment: # Detritus at base of column as sediment (mol m-2)
+            caco3_sediment: # CaCO3 at base of column as sediment (mol m-2)
+
+    'monthly 2d BGC fields':
+        defaults:  # these can be overridden for individual fields below
+            file_name_dimension: 2d  # descriptor for filename, e.g. 3d, 2d, scalar
+            reduction_method: mean
+            module_name: generic_wombatlite
+        fields:
+            pco2: # Surface aqueous partial pressure of CO2 (uatm)
+            paco2: # Surface aqueous partial pressure of CO2 inc. anthropogenic (uatm)
+            light_limit: # Integrated light limitation of phytoplankton growth (m)
+            radbio1: # Photosynthetically active radiation for phytoplankton growth at surface (W m-2)
+            det_sed_remin: # Rate of remineralisation of detritus in accumulated sediment (mol/m^2/s)
+            det_sed_depst: # Rate of deposition of detritus to sediment at base of water column (mol/m^2/s)
+            caco3_sed_remin: # Rate of remineralisation of CaCO3 in accumulated sediment (mol/m^2/s)
+            caco3_sed_depst: # Rate of deposition of CaCO3 to sediment at base of water column (mol/m^2/s)
+            wdet100: # Detritus export at 100 m (det*sinking rate) (mol/m^2/s)
+            npp2d: # Vertically integrated net primary productivity (mol/m^2/s)
+            npp1: # Net primary productivity in the first ocean layer (mol/kg/s)
+            pprod_gross_2d: # Vertically integrated gross phytoplankton production (mol/m^2/s)
+            dic_intmld: # MLD-integrated natural dissolved inorganic carbon (mol/m^2)
+            adic_intmld: # MLD-integrated natural + anthropogenic dissolved inorganic carbon (mol/m^2)
+            o2_intmld: # MLD-integrated dissolved oxygen (mol/m^2)
+            no3_intmld: # MLD-integrated nitrate (mol/m^2)
+            fe_intmld: # MLD-integrated iron (mol/m^2)
+            phy_intmld: # MLD-integrated phytoplankton (mol/m^2)
+            det_intmld: # MLD-integrated detritus (mol/m^2)
+            pprod_gross_intmld: # MLD-integrated gross phytoplankton production (mol/m^2/s)
+            npp_intmld: # MLD-integrated net primary productivity (mol/m^2/s)
+            radbio_intmld: # MLD-integrated photosynthetically active radiation for phytoplankton growth (W m-1)
+            dic_int100: # 100m-integrated natural dissolved inorganic carbon (mol/m^2)
+            adic_int100: # 100m-integrated natural + anthropogenic dissolved inorganic carbon (mol/m^2)
+            o2_int100: # 100m-integrated dissolved oxygen (mol/m^2)
+            no3_int100: # 100m-integrated nitrate (mol/m^2)
+            fe_int100: # 100m-integrated iron (mol/m^2)
+            phy_int100: # 100m-integrated phytoplankton (mol/m^2)
+            det_int100: # 100m-integrated detritus (mol/m^2)
+            pprod_gross_int100: # 100m-integrated gross phytoplankton production (mol/m^2/s)
+            npp_int100: # 100m-integrated net primary productivity (mol/m^2/s)
+            radbio_int100: # 100m-integrated photosynthetically active radiation for phytoplankton growth (W m-1)
+            no3_stf: # Total flux of no3 into Ocean Surface (mole/m^2/sec)
+            no3_vstf: # Virtual flux of nitrate into ocean due to salinity restoring/correction (mol/m^2/s)
+            no3_btf: # Total flux of no3 into Ocean Bottom (mole/m^2/sec)
+            phy_stf: # Total flux of phy into Ocean Surface (mole/m^2/sec)
+            phy_trunoff: # River concentration of phy (mol/kg)
+            o2_stf: # Total flux of o2 into Ocean Surface (mole/m^2/sec)
+            o2_stf_gas: # Gas exchange flux of o2 into Ocean Surface (mole/m^2/sec)
+            o2_btf: # Total flux of o2 into Ocean Bottom (mole/m^2/sec)
+            o2_alpha: # Atmospheric saturation for o2 (mol/kg)
+            o2_csurf: # Ocean surface gas concentration of o2 (mol/kg)
+            o2_sc_no: # Ocean surface Schmidt Number for o2 (mol/kg)
+            adic_stf: # Total flux of adic into Ocean Surface (mole/m^2/sec)
+            adic_stf_gas: # Gas exchange flux of adic into Ocean Surface (mole/m^2/sec)
+            adic_vstf: # Virtual flux of natural + anthropogenic dissolved inorganic carbon into ocean due to salinity restoring/correction (mol/m^2/s)
+            alk_vstf: # Virtual flux of alkalinity into ocean due to salinity restoring/correction (mol/m^2/s)
+            adic_btf: # Total flux of adic into Ocean Bottom (mole/m^2/sec)
+            adic_alpha: # Atmospheric saturation for adic (mol/kg)
+            adic_csurf: # Ocean surface gas concentration of adic (mol/kg)
+            adic_sc_no: # Ocean surface Schmidt Number for adic (mol/kg)
+            dic_stf: # Total flux of dic into Ocean Surface (mole/m^2/sec)
+            dic_stf_gas: # Gas exchange flux of dic into Ocean Surface (mole/m^2/sec)
+            dic_vstf: # Virtual flux of natural dissolved inorganic carbon into ocean due to salinity restoring/correction (mol/m^2/s)
+            dic_btf: # Total flux of dic into Ocean Bottom (mole/m^2/sec)
+            dic_alpha: # Atmospheric saturation for dic (mol/kg)
+            dic_csurf: # Ocean surface gas concentration of dic (mol/kg)
+            dic_sc_no: # Ocean surface Schmidt Number for dic (mol/kg)
+            alk_stf: # Total flux of alk into Ocean Surface (mole/m^2/sec)
+            alk_vstf: # Virtual flux of alkalinity into ocean due to salinity restoring/correction (mol/m^2/s)
+            alk_btf: # Total flux of alk into Ocean Bottom (mole/m^2/sec)
+            fe_stf: # Total flux of fe into Ocean Surface (mole/m^2/sec)
+            fe_btf: # Total flux of fe into Ocean Bottom (mole/m^2/sec)

--- a/docs/available_diags.000000
+++ b/docs/available_diags.000000
@@ -1,4 +1,4 @@
-"volcello"  [Used]
+"volcello"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
     ! long_name: Ocean grid-cell volume
     ! units: m3
@@ -83,35 +83,35 @@
     ! modules: ocean_model
     ! long_name: Coriolis parameter at corner (Bu) points
     ! units: s-1
-"dxt"  [Unused]
+"dxt"  [Used]
     ! modules: ocean_model
     ! long_name: Delta(x) at thickness/tracer points (meter)
     ! units: m
-"dyt"  [Unused]
+"dyt"  [Used]
     ! modules: ocean_model
     ! long_name: Delta(y) at thickness/tracer points (meter)
     ! units: m
-"dxCu"  [Unused]
+"dxCu"  [Used]
     ! modules: ocean_model
     ! long_name: Delta(x) at u points (meter)
     ! units: m
-"dyCu"  [Unused]
+"dyCu"  [Used]
     ! modules: ocean_model
     ! long_name: Delta(y) at u points (meter)
     ! units: m
-"dxCv"  [Unused]
+"dxCv"  [Used]
     ! modules: ocean_model
     ! long_name: Delta(x) at v points (meter)
     ! units: m
-"dyCv"  [Unused]
+"dyCv"  [Used]
     ! modules: ocean_model
     ! long_name: Delta(y) at v points (meter)
     ! units: m
-"dyCuo"  [Unused]
+"dyCuo"  [Used]
     ! modules: ocean_model
     ! long_name: Open meridional grid spacing at u points (meter)
     ! units: m
-"dxCvo"  [Unused]
+"dxCvo"  [Used]
     ! modules: ocean_model
     ! long_name: Open zonal grid spacing at v points (meter)
     ! units: m
@@ -376,7 +376,7 @@
     ! units: kg s-1
     ! cell_methods: xh:sum yq:point zl:sum
     ! variants: {vhGM,vhGM_xyave}
-"GMwork"  [Unused] (CMOR equivalent is "tnkebto")
+"GMwork"  [Used] (CMOR equivalent is "tnkebto")
     ! modules: {ocean_model,ocean_model_d2}
     ! long_name: Integrated Tendency of Ocean Mesoscale Eddy KE from Parameterized Eddy Advection
     ! units: W m-2
@@ -1473,7 +1473,7 @@
     ! long_name: Mass of liquid ocean
     ! units: kg
     ! standard_name: sea_water_mass
-"thkcello"  [Unused]
+"thkcello"  [Used]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
     ! long_name: Cell Thickness
     ! units: m
@@ -1486,7 +1486,7 @@
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {h_pre_sync,h_pre_sync_xyave}
-"tob"  [Unused]
+"tob"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
     ! long_name: Sea Water Potential Temperature at Sea Floor
     ! units: degC
@@ -1586,7 +1586,7 @@
     ! units: m
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {e,e_xyave}
-"e_D"  [Unused]
+"e_D"  [Used]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
     ! long_name: Interface Height above the Seafloor
     ! units: m
@@ -1610,7 +1610,7 @@
     ! units: kg m-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {rhopot0,rhopot0_xyave}
-"rhopot2"  [Unused]
+"rhopot2"  [Used]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
     ! long_name: Potential density referenced to 2000 dbar
     ! units: kg m-3
@@ -1838,7 +1838,7 @@
     ! long_name: The height of the water column
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
-"pbo"  [Unused]
+"pbo"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
     ! long_name: Sea Water Pressure at Sea Floor
     ! units: Pa
@@ -1998,7 +1998,7 @@
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {Kd_salt,Kd_salt_xyave,difvso,difvso_xyave}
-"KPP_OBLdepth"  [Used] (CMOR equivalent is "oml")
+"KPP_OBLdepth"  [Unused] (CMOR equivalent is "oml")
     ! modules: {ocean_model,ocean_model_d2}
     ! long_name: Thickness of the surface Ocean Boundary Layer calculated by [CVMix] KPP
     ! units: meter
@@ -2375,7 +2375,7 @@
     ! units: W m-2
     ! standard_name: nondownwelling_shortwave_flux_in_sea_water
     ! cell_methods: xh:mean yh:mean area:mean
-"SW_pen"  [Unused]
+"SW_pen"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
     ! long_name: Penetrating shortwave radiation flux into ocean
     ! units: W m-2
@@ -2570,13 +2570,13 @@
     ! standard_name: ocean_mass_y_transport
     ! cell_methods: xh:sum yq:point zl:sum
     ! variants: {vmo,vmo_xyave}
-"umo_2d"  [Unused]
+"umo_2d"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
     ! long_name: Ocean Mass X Transport Vertical Sum
     ! units: kg s-1
     ! standard_name: ocean_mass_x_transport_vertical_sum
     ! cell_methods: xq:point yh:sum
-"vmo_2d"  [Unused]
+"vmo_2d"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
     ! long_name: Ocean Mass Y Transport Vertical Sum
     ! units: kg s-1
@@ -2606,25 +2606,25 @@
     ! units: degC
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {temp_post_horzn,temp_post_horzn_xyave}
-"T_adx"  [Unused]
+"T_adx"  [Used]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
     ! long_name: Advective (by residual mean) Zonal Flux of Heat
     ! units: W
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {T_adx,T_adx_xyave}
-"T_ady"  [Unused]
+"T_ady"  [Used]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
     ! long_name: Advective (by residual mean) Meridional Flux of Heat
     ! units: W
     ! cell_methods: xh:sum yq:point zl:sum
     ! variants: {T_ady,T_ady_xyave}
-"T_diffx"  [Unused]
+"T_diffx"  [Used]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
     ! long_name: Diffusive Zonal Flux of Heat
     ! units: W
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {T_diffx,T_diffx_xyave}
-"T_diffy"  [Unused]
+"T_diffy"  [Used]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
     ! long_name: Diffusive Meridional Flux of Heat
     ! units: W
@@ -2788,25 +2788,25 @@
     ! units: psu
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {salt_post_horzn,salt_post_horzn_xyave}
-"S_adx"  [Unused]
+"S_adx"  [Used]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
     ! long_name: Advective (by residual mean) Zonal Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {S_adx,S_adx_xyave}
-"S_ady"  [Unused]
+"S_ady"  [Used]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
     ! long_name: Advective (by residual mean) Meridional Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xh:sum yq:point zl:sum
     ! variants: {S_ady,S_ady_xyave}
-"S_diffx"  [Unused]
+"S_diffx"  [Used]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
     ! long_name: Diffusive Zonal Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {S_diffx,S_diffx_xyave}
-"S_diffy"  [Unused]
+"S_diffy"  [Used]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
     ! long_name: Diffusive Meridional Flux of Salt
     ! units: psu m3 s-1
@@ -2824,22 +2824,22 @@
     ! units: psu m3 s-1
     ! cell_methods: xh:sum yq:point zl:sum
     ! variants: {S_hbd_diffy,S_hbd_diffy_xyave}
-"S_adx_2d"  [Unused]
+"S_adx_2d"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
     ! long_name: Vertically Integrated Advective Zonal Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xq:point yh:sum
-"S_ady_2d"  [Unused]
+"S_ady_2d"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
     ! long_name: Vertically Integrated Advective Meridional Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xh:sum yq:point
-"S_diffx_2d"  [Unused]
+"S_diffx_2d"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
     ! long_name: Vertically Integrated Diffusive Zonal Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xq:point yh:sum
-"S_diffy_2d"  [Unused]
+"S_diffy_2d"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
     ! long_name: Vertically Integrated Diffusive Meridional Flux of Salt
     ! units: psu m3 s-1
@@ -4635,7 +4635,7 @@
     ! standard_name: rainfall_flux
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {lprec,prlq}
-"vprec"  [Used]
+"vprec"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
     ! long_name: Virtual liquid precip into ocean due to SSS restoring
     ! units: kg m-2 s-1
@@ -4692,7 +4692,7 @@
     ! units: kg s-1
     ! standard_name: water_flux_into_sea_water_due_to_sea_ice_thermodynamics_area_integrated
     ! variants: {total_icemelt,total_fsitherm}
-"total_precip"  [Unused]
+"total_precip"  [Used]
     ! modules: ocean_model
     ! long_name: Area integrated liquid+frozen precip into ocean
     ! units: kg s-1
@@ -4702,7 +4702,7 @@
     ! units: kg s-1
     ! standard_name: snowfall_flux_area_integrated
     ! variants: {total_fprec,total_prsn}
-"total_lprec"  [Unused]
+"total_lprec"  [Used]
     ! modules: ocean_model
     ! long_name: Area integrated liquid precip into ocean
     ! units: kg s-1
@@ -4722,11 +4722,11 @@
     ! long_name: Area integrated liquid runoff into ocean
     ! units: kg s-1
     ! variants: {total_lrunoff,total_friver}
-"total_net_massout"  [Unused]
+"total_net_massout"  [Used]
     ! modules: ocean_model
     ! long_name: Area integrated mass leaving ocean due to evap and seaice form
     ! units: kg s-1
-"total_net_massin"  [Unused]
+"total_net_massin"  [Used]
     ! modules: ocean_model
     ! long_name: Area integrated mass entering ocean due to predip, runoff, ice melt
     ! units: kg s-1
@@ -4774,7 +4774,7 @@
     ! units: W m-2
     ! standard_name: temperature_flux_due_to_runoff_expressed_as_heat_flux_into_sea_water
     ! cell_methods: xh:mean yh:mean area:mean
-"hfrunoffds"  [Unused]
+"hfrunoffds"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
     ! long_name: Heat content (relative to 0C) of liquid+solid runoff into ocean
     ! units: W m-2
@@ -4790,7 +4790,7 @@
     ! long_name: Heat content (relative to 0degC) of frozen prec entering ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
-"heat_content_vprec"  [Used]
+"heat_content_vprec"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
     ! long_name: Heat content (relative to 0degC) of virtual precip entering ocean
     ! units: W m-2
@@ -4805,7 +4805,7 @@
     ! long_name: Heat content (relative to 0degC) of water evaporating from ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
-"hfrainds"  [Unused]
+"hfrainds"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
     ! long_name: Heat content (relative to 0degC) of liquid+frozen precip entering ocean
     ! units: W m-2
@@ -4827,7 +4827,7 @@
     ! long_name: Heat content (relative to 0degC) of net mass entering ocean ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
-"net_heat_coupler"  [Unused]
+"net_heat_coupler"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
     ! long_name: Surface ocean heat flux from SW+LW+latent+sensible+seaice_melt_heat (via the coupler)
     ! units: W m-2
@@ -4898,7 +4898,7 @@
     ! standard_name: surface_downward_sensible_heat_flux
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {sensible,hfsso}
-"seaice_melt_heat"  [Used]
+"seaice_melt_heat"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
     ! long_name: Heat flux into ocean due to snow and sea ice melt/freeze
     ! units: W m-2
@@ -5047,7 +5047,7 @@
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {salt_flux,sfdsi}
-"salt_flux_in"  [Unused]
+"salt_flux_in"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
     ! long_name: Salt flux into ocean at surface from coupler
     ! units: kg m-2 s-1
@@ -5062,7 +5062,7 @@
     ! long_name: Salt left in ocean at surface due to ice formation
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
-"salt_flux_global_restoring_adjustment"  [Unused]
+"salt_flux_global_restoring_adjustment"  [Used]
     ! modules: ocean_model
     ! long_name: Adjustment needed to balance net global salt flux into ocean at surface
     ! units: kg m-2 s-1
@@ -5070,7 +5070,7 @@
     ! modules: ocean_model
     ! long_name: Adjustment needed to adjust net vprec into ocean to zero
     ! units: kg m-2 s-1
-"net_fresh_water_global_adjustment"  [Unused]
+"net_fresh_water_global_adjustment"  [Used]
     ! modules: ocean_model
     ! long_name: Adjustment needed to adjust net fresh water into ocean to zero
     ! units: kg m-2 s-1
@@ -5086,16 +5086,16 @@
     ! modules: ocean_model
     ! long_name: Scaling applied to adjust net fresh water into ocean to zero
     ! units: nondim
-"total_salt_flux"  [Unused]
+"total_salt_flux"  [Used]
     ! modules: ocean_model
     ! long_name: Area integrated surface salt flux
     ! units: kg s-1
     ! variants: {total_salt_flux,total_sfdsi}
-"total_salt_Flux_In"  [Unused]
+"total_salt_Flux_In"  [Used]
     ! modules: ocean_model
     ! long_name: Area integrated surface salt flux at surface from coupler
     ! units: kg s-1
-"total_salt_Flux_Added"  [Unused]
+"total_salt_Flux_Added"  [Used]
     ! modules: ocean_model
     ! long_name: Area integrated surface salt flux due to restoring or flux adjustment
     ! units: kg s-1

--- a/input.nml
+++ b/input.nml
@@ -24,6 +24,9 @@
 
 &diag_manager_nml
     flush_nc_files = .true.
+    max_axes = 400
+    max_files = 200
+    max_num_axis_sets = 200
 /
 
 &mpp_io_nml


### PR DESCRIPTION
**1. Summary**:

Cherry-pick diag_table changes from https://github.com/ACCESS-NRI/access-om3-configs/pull/157
**2. Issues Addressed:**
<!-- Add links to github issue(s) this is related to -->
- https://github.com/ACCESS-NRI/access-om3-configs/issues/438

**3. Ad-hoc Testing**
<!-- What ad-hoc testing was done. How are you convinced this is correct? -->
`FATAL from PE     0: diag_manager_mod::init_field_cell_measures: VOLUME measures field "ocean_model/volcello" NOT in diag_table with correct output frequency for field ocean_model/diftrblo`

---
Include wombatlite specific diagnostics as well.