### PR TITLE
Reduce MOM diagnostic output frequency to annual files

### DIFF
--- a/diag_table
+++ b/diag_table
@@ -358,9 +358,6 @@ ACCESS-OM3
 "access-om3.mom6.2d.mlotst.1day.mean.%4yr", 1, "days", 1, "days", "time", 1, "years"
 "ocean_model", "mlotst", "mlotst", "access-om3.mom6.2d.mlotst.1day.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.e_D.1day.mean.%4yr", 1, "days", 1, "days", "time", 1, "years"
-"ocean_model", "e_D", "e_D", "access-om3.mom6.2d.e_D.1day.mean.%4yr", "all", "average", "none", 2
-
 "access-om3.mom6.2d.net_heat_coupler.1day.mean.%4yr", 1, "days", 1, "days", "time", 1, "years"
 "ocean_model", "net_heat_coupler", "net_heat_coupler", "access-om3.mom6.2d.net_heat_coupler.1day.mean.%4yr", "all", "average", "none", 2
 
@@ -385,14 +382,17 @@ ACCESS-OM3
 
 # daily 2D max fields
 
-"access-om3.mom6.2d.e_D.1day.max.%4yr", 1, "days", 1, "days", "time", 1, "years"
-"ocean_model", "e_D", "e_D", "access-om3.mom6.2d.e_D.1day.max.%4yr", "all", "max", "none", 2
+"access-om3.mom6.2d.tob.1day.max.%4yr", 1, "days", 1, "days", "time", 1, "years"
+"ocean_model", "tob", "tob", "access-om3.mom6.2d.tob.1day.max.%4yr", "all", "max", "none", 2
 
 "access-om3.mom6.2d.tos.1day.max.%4yr", 1, "days", 1, "days", "time", 1, "years"
 "ocean_model", "tos", "tos", "access-om3.mom6.2d.tos.1day.max.%4yr", "all", "max", "none", 2
 
 
 # daily 2D min fields
+
+"access-om3.mom6.2d.tob.1day.min.%4yr", 1, "days", 1, "days", "time", 1, "years"
+"ocean_model", "tob", "tob", "access-om3.mom6.2d.tob.1day.min.%4yr", "all", "min", "none", 2
 
 "access-om3.mom6.2d.tos.1day.min.%4yr", 1, "days", 1, "days", "time", 1, "years"
 "ocean_model", "tos", "tos", "access-om3.mom6.2d.tos.1day.min.%4yr", "all", "min", "none", 2

--- a/diag_table
+++ b/diag_table
@@ -43,380 +43,380 @@ ACCESS-OM3
 
 # monthly 3d fields
 
-"access-om3.mom6.3d.h.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "h", "h", "access-om3.mom6.3d.h.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.h.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "h", "h", "access-om3.mom6.3d.h.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.e.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "e", "e", "access-om3.mom6.3d.e.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.e.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "e", "e", "access-om3.mom6.3d.e.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.agessc.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "agessc", "agessc", "access-om3.mom6.3d.agessc.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.agessc.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "agessc", "agessc", "access-om3.mom6.3d.agessc.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.difmxybo.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "difmxybo", "difmxybo", "access-om3.mom6.3d.difmxybo.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.difmxybo.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "difmxybo", "difmxybo", "access-om3.mom6.3d.difmxybo.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.difmxylo.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "difmxylo", "difmxylo", "access-om3.mom6.3d.difmxylo.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.difmxylo.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "difmxylo", "difmxylo", "access-om3.mom6.3d.difmxylo.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.diftrelo.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "diftrelo", "diftrelo", "access-om3.mom6.3d.diftrelo.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.diftrelo.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "diftrelo", "diftrelo", "access-om3.mom6.3d.diftrelo.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.diftrblo.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "diftrblo", "diftrblo", "access-om3.mom6.3d.diftrblo.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.diftrblo.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "diftrblo", "diftrblo", "access-om3.mom6.3d.diftrblo.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.rhopot0.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "rhopot0", "rhopot0", "access-om3.mom6.3d.rhopot0.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.rhopot0.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "rhopot0", "rhopot0", "access-om3.mom6.3d.rhopot0.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.rhopot2.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "rhopot2", "rhopot2", "access-om3.mom6.3d.rhopot2.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.rhopot2.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "rhopot2", "rhopot2", "access-om3.mom6.3d.rhopot2.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.thetao.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "thetao", "thetao", "access-om3.mom6.3d.thetao.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.thetao.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "thetao", "thetao", "access-om3.mom6.3d.thetao.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.so.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "so", "so", "access-om3.mom6.3d.so.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.so.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "so", "so", "access-om3.mom6.3d.so.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.T_adx.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "T_adx", "T_adx", "access-om3.mom6.3d.T_adx.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.T_adx.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "T_adx", "T_adx", "access-om3.mom6.3d.T_adx.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.T_ady.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "T_ady", "T_ady", "access-om3.mom6.3d.T_ady.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.T_ady.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "T_ady", "T_ady", "access-om3.mom6.3d.T_ady.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.S_adx.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "S_adx", "S_adx", "access-om3.mom6.3d.S_adx.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.S_adx.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "S_adx", "S_adx", "access-om3.mom6.3d.S_adx.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.S_ady.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "S_ady", "S_ady", "access-om3.mom6.3d.S_ady.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.S_ady.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "S_ady", "S_ady", "access-om3.mom6.3d.S_ady.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.T_diffx.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "T_diffx", "T_diffx", "access-om3.mom6.3d.T_diffx.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.T_diffx.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "T_diffx", "T_diffx", "access-om3.mom6.3d.T_diffx.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.T_diffy.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "T_diffy", "T_diffy", "access-om3.mom6.3d.T_diffy.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.T_diffy.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "T_diffy", "T_diffy", "access-om3.mom6.3d.T_diffy.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.S_diffx.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "S_diffx", "S_diffx", "access-om3.mom6.3d.S_diffx.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.S_diffx.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "S_diffx", "S_diffx", "access-om3.mom6.3d.S_diffx.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.S_diffy.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "S_diffy", "S_diffy", "access-om3.mom6.3d.S_diffy.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.S_diffy.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "S_diffy", "S_diffy", "access-om3.mom6.3d.S_diffy.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.umo.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "umo", "umo", "access-om3.mom6.3d.umo.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.umo.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "umo", "umo", "access-om3.mom6.3d.umo.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.vmo.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "vmo", "vmo", "access-om3.mom6.3d.vmo.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.vmo.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "vmo", "vmo", "access-om3.mom6.3d.vmo.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.uo.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "uo", "uo", "access-om3.mom6.3d.uo.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.uo.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "uo", "uo", "access-om3.mom6.3d.uo.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.vo.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "vo", "vo", "access-om3.mom6.3d.vo.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.vo.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "vo", "vo", "access-om3.mom6.3d.vo.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.uh.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "uh", "uh", "access-om3.mom6.3d.uh.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.uh.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "uh", "uh", "access-om3.mom6.3d.uh.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.vh.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "vh", "vh", "access-om3.mom6.3d.vh.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.vh.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "vh", "vh", "access-om3.mom6.3d.vh.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.uhGM.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "uhGM", "uhGM", "access-om3.mom6.3d.uhGM.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.uhGM.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "uhGM", "uhGM", "access-om3.mom6.3d.uhGM.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.vhGM.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "vhGM", "vhGM", "access-om3.mom6.3d.vhGM.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.vhGM.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "vhGM", "vhGM", "access-om3.mom6.3d.vhGM.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.uhml.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "uhml", "uhml", "access-om3.mom6.3d.uhml.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.uhml.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "uhml", "uhml", "access-om3.mom6.3d.uhml.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.vhml.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "vhml", "vhml", "access-om3.mom6.3d.vhml.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.vhml.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "vhml", "vhml", "access-om3.mom6.3d.vhml.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.thkcello.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "thkcello", "thkcello", "access-om3.mom6.3d.thkcello.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.thkcello.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "thkcello", "thkcello", "access-om3.mom6.3d.thkcello.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.KE.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "KE", "KE", "access-om3.mom6.3d.KE.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.3d.KE.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "KE", "KE", "access-om3.mom6.3d.KE.1mon.mean.%4yr", "all", "average", "none", 2
 
 
 # monthly 3d squared fields
 
-"access-om3.mom6.3d.uo.1mon.pow02.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "uo", "uo", "access-om3.mom6.3d.uo.1mon.pow02.%4yr%2mo", "all", "pow02", "none", 2
+"access-om3.mom6.3d.uo.1mon.pow02.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "uo", "uo", "access-om3.mom6.3d.uo.1mon.pow02.%4yr", "all", "pow02", "none", 2
 
-"access-om3.mom6.3d.vo.1mon.pow02.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "vo", "vo", "access-om3.mom6.3d.vo.1mon.pow02.%4yr%2mo", "all", "pow02", "none", 2
+"access-om3.mom6.3d.vo.1mon.pow02.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "vo", "vo", "access-om3.mom6.3d.vo.1mon.pow02.%4yr", "all", "pow02", "none", 2
 
 
 # monthly 2d fields
 
-"access-om3.mom6.2d.evs.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "evs", "evs", "access-om3.mom6.2d.evs.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.evs.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "evs", "evs", "access-om3.mom6.2d.evs.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.ficeberg.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "ficeberg", "ficeberg", "access-om3.mom6.2d.ficeberg.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.ficeberg.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "ficeberg", "ficeberg", "access-om3.mom6.2d.ficeberg.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.friver.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "friver", "friver", "access-om3.mom6.2d.friver.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.friver.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "friver", "friver", "access-om3.mom6.2d.friver.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.fsitherm.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "fsitherm", "fsitherm", "access-om3.mom6.2d.fsitherm.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.fsitherm.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "fsitherm", "fsitherm", "access-om3.mom6.2d.fsitherm.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.heat_content_cond.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "heat_content_cond", "heat_content_cond", "access-om3.mom6.2d.heat_content_cond.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.heat_content_cond.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "heat_content_cond", "heat_content_cond", "access-om3.mom6.2d.heat_content_cond.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.heat_content_evap.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "heat_content_evap", "heat_content_evap", "access-om3.mom6.2d.heat_content_evap.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.heat_content_evap.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "heat_content_evap", "heat_content_evap", "access-om3.mom6.2d.heat_content_evap.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.heat_content_fprec.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "heat_content_fprec", "heat_content_fprec", "access-om3.mom6.2d.heat_content_fprec.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.heat_content_fprec.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "heat_content_fprec", "heat_content_fprec", "access-om3.mom6.2d.heat_content_fprec.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.heat_content_frunoff.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "heat_content_frunoff", "heat_content_frunoff", "access-om3.mom6.2d.heat_content_frunoff.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.heat_content_frunoff.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "heat_content_frunoff", "heat_content_frunoff", "access-om3.mom6.2d.heat_content_frunoff.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.heat_content_lrunoff.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "heat_content_lrunoff", "heat_content_lrunoff", "access-om3.mom6.2d.heat_content_lrunoff.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.heat_content_lrunoff.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "heat_content_lrunoff", "heat_content_lrunoff", "access-om3.mom6.2d.heat_content_lrunoff.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.heat_content_lprec.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "heat_content_lprec", "heat_content_lprec", "access-om3.mom6.2d.heat_content_lprec.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.heat_content_lprec.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "heat_content_lprec", "heat_content_lprec", "access-om3.mom6.2d.heat_content_lprec.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.hfrunoffds.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "hfrunoffds", "hfrunoffds", "access-om3.mom6.2d.hfrunoffds.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.hfrunoffds.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "hfrunoffds", "hfrunoffds", "access-om3.mom6.2d.hfrunoffds.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.hfrainds.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "hfrainds", "hfrainds", "access-om3.mom6.2d.hfrainds.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.hfrainds.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "hfrainds", "hfrainds", "access-om3.mom6.2d.hfrainds.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.Heat_PmE.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "Heat_PmE", "Heat_PmE", "access-om3.mom6.2d.Heat_PmE.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.Heat_PmE.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "Heat_PmE", "Heat_PmE", "access-om3.mom6.2d.Heat_PmE.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.net_heat_coupler.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "net_heat_coupler", "net_heat_coupler", "access-om3.mom6.2d.net_heat_coupler.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.net_heat_coupler.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "net_heat_coupler", "net_heat_coupler", "access-om3.mom6.2d.net_heat_coupler.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.hfds.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "hfds", "hfds", "access-om3.mom6.2d.hfds.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.hfds.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "hfds", "hfds", "access-om3.mom6.2d.hfds.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.hflso.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "hflso", "hflso", "access-om3.mom6.2d.hflso.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.hflso.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "hflso", "hflso", "access-om3.mom6.2d.hflso.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.hfsifrazil.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "hfsifrazil", "hfsifrazil", "access-om3.mom6.2d.hfsifrazil.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.hfsifrazil.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "hfsifrazil", "hfsifrazil", "access-om3.mom6.2d.hfsifrazil.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.hfsnthermds.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "hfsnthermds", "hfsnthermds", "access-om3.mom6.2d.hfsnthermds.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.hfsnthermds.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "hfsnthermds", "hfsnthermds", "access-om3.mom6.2d.hfsnthermds.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.hfsso.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "hfsso", "hfsso", "access-om3.mom6.2d.hfsso.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.hfsso.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "hfsso", "hfsso", "access-om3.mom6.2d.hfsso.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.prlq.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "prlq", "prlq", "access-om3.mom6.2d.prlq.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.prlq.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "prlq", "prlq", "access-om3.mom6.2d.prlq.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.prsn.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "prsn", "prsn", "access-om3.mom6.2d.prsn.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.prsn.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "prsn", "prsn", "access-om3.mom6.2d.prsn.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.wfo.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "wfo", "wfo", "access-om3.mom6.2d.wfo.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.wfo.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "wfo", "wfo", "access-om3.mom6.2d.wfo.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.pso.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "pso", "pso", "access-om3.mom6.2d.pso.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.pso.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "pso", "pso", "access-om3.mom6.2d.pso.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.rlntds.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "rlntds", "rlntds", "access-om3.mom6.2d.rlntds.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.rlntds.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "rlntds", "rlntds", "access-om3.mom6.2d.rlntds.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.rsntds.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "rsntds", "rsntds", "access-om3.mom6.2d.rsntds.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.rsntds.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "rsntds", "rsntds", "access-om3.mom6.2d.rsntds.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.sfdsi.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "sfdsi", "sfdsi", "access-om3.mom6.2d.sfdsi.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.sfdsi.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "sfdsi", "sfdsi", "access-om3.mom6.2d.sfdsi.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.salt_flux_added.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "salt_flux_added", "salt_flux_added", "access-om3.mom6.2d.salt_flux_added.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.salt_flux_added.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "salt_flux_added", "salt_flux_added", "access-om3.mom6.2d.salt_flux_added.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.somint.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "somint", "somint", "access-om3.mom6.2d.somint.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.somint.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "somint", "somint", "access-om3.mom6.2d.somint.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.opottempmint.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "opottempmint", "opottempmint", "access-om3.mom6.2d.opottempmint.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.opottempmint.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "opottempmint", "opottempmint", "access-om3.mom6.2d.opottempmint.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.Rd_dx.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "Rd_dx", "Rd_dx", "access-om3.mom6.2d.Rd_dx.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.Rd_dx.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "Rd_dx", "Rd_dx", "access-om3.mom6.2d.Rd_dx.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.mass_wt.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "mass_wt", "mass_wt", "access-om3.mom6.2d.mass_wt.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.mass_wt.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "mass_wt", "mass_wt", "access-om3.mom6.2d.mass_wt.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.mlotst.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "mlotst", "mlotst", "access-om3.mom6.2d.mlotst.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.mlotst.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "mlotst", "mlotst", "access-om3.mom6.2d.mlotst.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.sos.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "sos", "sos", "access-om3.mom6.2d.sos.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.sos.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "sos", "sos", "access-om3.mom6.2d.sos.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.speed.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "speed", "speed", "access-om3.mom6.2d.speed.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.speed.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "speed", "speed", "access-om3.mom6.2d.speed.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.tos.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "tos", "tos", "access-om3.mom6.2d.tos.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.tos.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "tos", "tos", "access-om3.mom6.2d.tos.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.SSH.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "SSH", "SSH", "access-om3.mom6.2d.SSH.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.SSH.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "SSH", "SSH", "access-om3.mom6.2d.SSH.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.SSU.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "SSU", "SSU", "access-om3.mom6.2d.SSU.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.SSU.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "SSU", "SSU", "access-om3.mom6.2d.SSU.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.SSV.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "SSV", "SSV", "access-om3.mom6.2d.SSV.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.SSV.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "SSV", "SSV", "access-om3.mom6.2d.SSV.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.T_adx_2d.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "T_adx_2d", "T_adx_2d", "access-om3.mom6.2d.T_adx_2d.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.T_adx_2d.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "T_adx_2d", "T_adx_2d", "access-om3.mom6.2d.T_adx_2d.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.T_ady_2d.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "T_ady_2d", "T_ady_2d", "access-om3.mom6.2d.T_ady_2d.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.T_ady_2d.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "T_ady_2d", "T_ady_2d", "access-om3.mom6.2d.T_ady_2d.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.T_diffx_2d.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "T_diffx_2d", "T_diffx_2d", "access-om3.mom6.2d.T_diffx_2d.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.T_diffx_2d.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "T_diffx_2d", "T_diffx_2d", "access-om3.mom6.2d.T_diffx_2d.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.T_diffy_2d.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "T_diffy_2d", "T_diffy_2d", "access-om3.mom6.2d.T_diffy_2d.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.T_diffy_2d.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "T_diffy_2d", "T_diffy_2d", "access-om3.mom6.2d.T_diffy_2d.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.S_adx_2d.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "S_adx_2d", "S_adx_2d", "access-om3.mom6.2d.S_adx_2d.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.S_adx_2d.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "S_adx_2d", "S_adx_2d", "access-om3.mom6.2d.S_adx_2d.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.S_ady_2d.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "S_ady_2d", "S_ady_2d", "access-om3.mom6.2d.S_ady_2d.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.S_ady_2d.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "S_ady_2d", "S_ady_2d", "access-om3.mom6.2d.S_ady_2d.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.S_diffx_2d.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "S_diffx_2d", "S_diffx_2d", "access-om3.mom6.2d.S_diffx_2d.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.S_diffx_2d.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "S_diffx_2d", "S_diffx_2d", "access-om3.mom6.2d.S_diffx_2d.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.S_diffy_2d.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "S_diffy_2d", "S_diffy_2d", "access-om3.mom6.2d.S_diffy_2d.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.S_diffy_2d.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "S_diffy_2d", "S_diffy_2d", "access-om3.mom6.2d.S_diffy_2d.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.tauuo.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "tauuo", "tauuo", "access-om3.mom6.2d.tauuo.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.tauuo.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "tauuo", "tauuo", "access-om3.mom6.2d.tauuo.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.tauvo.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "tauvo", "tauvo", "access-om3.mom6.2d.tauvo.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.tauvo.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "tauvo", "tauvo", "access-om3.mom6.2d.tauvo.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.uhbt.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "uhbt", "uhbt", "access-om3.mom6.2d.uhbt.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.uhbt.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "uhbt", "uhbt", "access-om3.mom6.2d.uhbt.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.vhbt.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "vhbt", "vhbt", "access-om3.mom6.2d.vhbt.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.vhbt.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "vhbt", "vhbt", "access-om3.mom6.2d.vhbt.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.ustar.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "ustar", "ustar", "access-om3.mom6.2d.ustar.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.ustar.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "ustar", "ustar", "access-om3.mom6.2d.ustar.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.umo_2d.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "umo_2d", "umo_2d", "access-om3.mom6.2d.umo_2d.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.umo_2d.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "umo_2d", "umo_2d", "access-om3.mom6.2d.umo_2d.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.vmo_2d.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "vmo_2d", "vmo_2d", "access-om3.mom6.2d.vmo_2d.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.vmo_2d.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "vmo_2d", "vmo_2d", "access-om3.mom6.2d.vmo_2d.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.pbo.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "pbo", "pbo", "access-om3.mom6.2d.pbo.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.pbo.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "pbo", "pbo", "access-om3.mom6.2d.pbo.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.SW_pen.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "SW_pen", "SW_pen", "access-om3.mom6.2d.SW_pen.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.SW_pen.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "SW_pen", "SW_pen", "access-om3.mom6.2d.SW_pen.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.salt_flux_in.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "salt_flux_in", "salt_flux_in", "access-om3.mom6.2d.salt_flux_in.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.salt_flux_in.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "salt_flux_in", "salt_flux_in", "access-om3.mom6.2d.salt_flux_in.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.tnkebto.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "tnkebto", "tnkebto", "access-om3.mom6.2d.tnkebto.1mon.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.tnkebto.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "tnkebto", "tnkebto", "access-om3.mom6.2d.tnkebto.1mon.mean.%4yr", "all", "average", "none", 2
 
 
 # monthly 2d max fields
 
-"access-om3.mom6.2d.mlotst.1mon.max.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "mlotst", "mlotst", "access-om3.mom6.2d.mlotst.1mon.max.%4yr%2mo", "all", "max", "none", 2
+"access-om3.mom6.2d.mlotst.1mon.max.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "mlotst", "mlotst", "access-om3.mom6.2d.mlotst.1mon.max.%4yr", "all", "max", "none", 2
 
-"access-om3.mom6.2d.sos.1mon.max.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "sos", "sos", "access-om3.mom6.2d.sos.1mon.max.%4yr%2mo", "all", "max", "none", 2
+"access-om3.mom6.2d.sos.1mon.max.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "sos", "sos", "access-om3.mom6.2d.sos.1mon.max.%4yr", "all", "max", "none", 2
 
-"access-om3.mom6.2d.tos.1mon.max.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "tos", "tos", "access-om3.mom6.2d.tos.1mon.max.%4yr%2mo", "all", "max", "none", 2
+"access-om3.mom6.2d.tos.1mon.max.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "tos", "tos", "access-om3.mom6.2d.tos.1mon.max.%4yr", "all", "max", "none", 2
 
-"access-om3.mom6.2d.SSH.1mon.max.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "SSH", "SSH", "access-om3.mom6.2d.SSH.1mon.max.%4yr%2mo", "all", "max", "none", 2
+"access-om3.mom6.2d.SSH.1mon.max.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "SSH", "SSH", "access-om3.mom6.2d.SSH.1mon.max.%4yr", "all", "max", "none", 2
 
 
 # monthly 2d min fields
 
-"access-om3.mom6.2d.mlotst.1mon.min.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "mlotst", "mlotst", "access-om3.mom6.2d.mlotst.1mon.min.%4yr%2mo", "all", "min", "none", 2
+"access-om3.mom6.2d.mlotst.1mon.min.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "mlotst", "mlotst", "access-om3.mom6.2d.mlotst.1mon.min.%4yr", "all", "min", "none", 2
 
-"access-om3.mom6.2d.sos.1mon.min.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "sos", "sos", "access-om3.mom6.2d.sos.1mon.min.%4yr%2mo", "all", "min", "none", 2
+"access-om3.mom6.2d.sos.1mon.min.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "sos", "sos", "access-om3.mom6.2d.sos.1mon.min.%4yr", "all", "min", "none", 2
 
-"access-om3.mom6.2d.tos.1mon.min.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "tos", "tos", "access-om3.mom6.2d.tos.1mon.min.%4yr%2mo", "all", "min", "none", 2
+"access-om3.mom6.2d.tos.1mon.min.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "tos", "tos", "access-om3.mom6.2d.tos.1mon.min.%4yr", "all", "min", "none", 2
 
-"access-om3.mom6.2d.SSH.1mon.min.%4yr%2mo", 1, "months", 1, "days", "time", 1, "months"
-"ocean_model", "SSH", "SSH", "access-om3.mom6.2d.SSH.1mon.min.%4yr%2mo", "all", "min", "none", 2
+"access-om3.mom6.2d.SSH.1mon.min.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "SSH", "SSH", "access-om3.mom6.2d.SSH.1mon.min.%4yr", "all", "min", "none", 2
 
 
 # daily 2D fields
 
-"access-om3.mom6.2d.tob.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 1, "months"
-"ocean_model", "tob", "tob", "access-om3.mom6.2d.tob.1day.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.tob.1day.mean.%4yr", 1, "days", 1, "days", "time", 1, "years"
+"ocean_model", "tob", "tob", "access-om3.mom6.2d.tob.1day.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.mlotst.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 1, "months"
-"ocean_model", "mlotst", "mlotst", "access-om3.mom6.2d.mlotst.1day.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.mlotst.1day.mean.%4yr", 1, "days", 1, "days", "time", 1, "years"
+"ocean_model", "mlotst", "mlotst", "access-om3.mom6.2d.mlotst.1day.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.e_D.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 1, "months"
-"ocean_model", "e_D", "e_D", "access-om3.mom6.2d.e_D.1day.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.e_D.1day.mean.%4yr", 1, "days", 1, "days", "time", 1, "years"
+"ocean_model", "e_D", "e_D", "access-om3.mom6.2d.e_D.1day.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.net_heat_coupler.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 1, "months"
-"ocean_model", "net_heat_coupler", "net_heat_coupler", "access-om3.mom6.2d.net_heat_coupler.1day.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.net_heat_coupler.1day.mean.%4yr", 1, "days", 1, "days", "time", 1, "years"
+"ocean_model", "net_heat_coupler", "net_heat_coupler", "access-om3.mom6.2d.net_heat_coupler.1day.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.heat_content_lrunoff.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 1, "months"
-"ocean_model", "heat_content_lrunoff", "heat_content_lrunoff", "access-om3.mom6.2d.heat_content_lrunoff.1day.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.heat_content_lrunoff.1day.mean.%4yr", 1, "days", 1, "days", "time", 1, "years"
+"ocean_model", "heat_content_lrunoff", "heat_content_lrunoff", "access-om3.mom6.2d.heat_content_lrunoff.1day.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.Heat_PmE.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 1, "months"
-"ocean_model", "Heat_PmE", "Heat_PmE", "access-om3.mom6.2d.Heat_PmE.1day.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.Heat_PmE.1day.mean.%4yr", 1, "days", 1, "days", "time", 1, "years"
+"ocean_model", "Heat_PmE", "Heat_PmE", "access-om3.mom6.2d.Heat_PmE.1day.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.tos.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 1, "months"
-"ocean_model", "tos", "tos", "access-om3.mom6.2d.tos.1day.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.tos.1day.mean.%4yr", 1, "days", 1, "days", "time", 1, "years"
+"ocean_model", "tos", "tos", "access-om3.mom6.2d.tos.1day.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.sos.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 1, "months"
-"ocean_model", "sos", "sos", "access-om3.mom6.2d.sos.1day.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.sos.1day.mean.%4yr", 1, "days", 1, "days", "time", 1, "years"
+"ocean_model", "sos", "sos", "access-om3.mom6.2d.sos.1day.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.SSU.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 1, "months"
-"ocean_model", "SSU", "SSU", "access-om3.mom6.2d.SSU.1day.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.SSU.1day.mean.%4yr", 1, "days", 1, "days", "time", 1, "years"
+"ocean_model", "SSU", "SSU", "access-om3.mom6.2d.SSU.1day.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.SSV.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 1, "months"
-"ocean_model", "SSV", "SSV", "access-om3.mom6.2d.SSV.1day.mean.%4yr%2mo", "all", "average", "none", 2
+"access-om3.mom6.2d.SSV.1day.mean.%4yr", 1, "days", 1, "days", "time", 1, "years"
+"ocean_model", "SSV", "SSV", "access-om3.mom6.2d.SSV.1day.mean.%4yr", "all", "average", "none", 2
 
 
 # daily 2D max fields
 
-"access-om3.mom6.2d.e_D.1day.max.%4yr%2mo", 1, "days", 1, "days", "time", 1, "months"
-"ocean_model", "e_D", "e_D", "access-om3.mom6.2d.e_D.1day.max.%4yr%2mo", "all", "max", "none", 2
+"access-om3.mom6.2d.e_D.1day.max.%4yr", 1, "days", 1, "days", "time", 1, "years"
+"ocean_model", "e_D", "e_D", "access-om3.mom6.2d.e_D.1day.max.%4yr", "all", "max", "none", 2
 
-"access-om3.mom6.2d.tos.1day.max.%4yr%2mo", 1, "days", 1, "days", "time", 1, "months"
-"ocean_model", "tos", "tos", "access-om3.mom6.2d.tos.1day.max.%4yr%2mo", "all", "max", "none", 2
+"access-om3.mom6.2d.tos.1day.max.%4yr", 1, "days", 1, "days", "time", 1, "years"
+"ocean_model", "tos", "tos", "access-om3.mom6.2d.tos.1day.max.%4yr", "all", "max", "none", 2
 
 
 # daily 2D min fields
 
-"access-om3.mom6.2d.tos.1day.min.%4yr%2mo", 1, "days", 1, "days", "time", 1, "months"
-"ocean_model", "tos", "tos", "access-om3.mom6.2d.tos.1day.min.%4yr%2mo", "all", "min", "none", 2
+"access-om3.mom6.2d.tos.1day.min.%4yr", 1, "days", 1, "days", "time", 1, "years"
+"ocean_model", "tos", "tos", "access-om3.mom6.2d.tos.1day.min.%4yr", "all", "min", "none", 2
 
 
 # daily scalar timeseries
 
-"access-om3.mom6.scalar.1day.snap.%4yr%2mo", 1, "days", 1, "days", "time", 1, "months"
-"ocean_model", "soga", "soga", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "thetaoga", "thetaoga", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "tosga", "tosga", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "sosga", "sosga", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_salt_Flux_Added", "total_salt_Flux_Added", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_salt_Flux_In", "total_salt_Flux_In", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_salt_flux", "total_salt_flux", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "net_fresh_water_global_adjustment", "net_fresh_water_global_adjustment", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "salt_flux_global_restoring_adjustment", "salt_flux_global_restoring_adjustment", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_wfo", "total_wfo", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_evs", "total_evs", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_fsitherm", "total_fsitherm", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_precip", "total_precip", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_prsn", "total_prsn", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_lprec", "total_lprec", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_ficeberg", "total_ficeberg", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_friver", "total_friver", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_net_massout", "total_net_massout", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_net_massin", "total_net_massin", "access-om3.mom6.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"access-om3.mom6.scalar.1day.snap.%4yr", 1, "days", 1, "days", "time", 1, "years"
+"ocean_model", "soga", "soga", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
+"ocean_model", "thetaoga", "thetaoga", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
+"ocean_model", "tosga", "tosga", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
+"ocean_model", "sosga", "sosga", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
+"ocean_model", "total_salt_Flux_Added", "total_salt_Flux_Added", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
+"ocean_model", "total_salt_Flux_In", "total_salt_Flux_In", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
+"ocean_model", "total_salt_flux", "total_salt_flux", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
+"ocean_model", "net_fresh_water_global_adjustment", "net_fresh_water_global_adjustment", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
+"ocean_model", "salt_flux_global_restoring_adjustment", "salt_flux_global_restoring_adjustment", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
+"ocean_model", "total_wfo", "total_wfo", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
+"ocean_model", "total_evs", "total_evs", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
+"ocean_model", "total_fsitherm", "total_fsitherm", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
+"ocean_model", "total_precip", "total_precip", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
+"ocean_model", "total_prsn", "total_prsn", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
+"ocean_model", "total_lprec", "total_lprec", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
+"ocean_model", "total_ficeberg", "total_ficeberg", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
+"ocean_model", "total_friver", "total_friver", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
+"ocean_model", "total_net_massout", "total_net_massout", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
+"ocean_model", "total_net_massin", "total_net_massin", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1

--- a/diag_table_source.yaml
+++ b/diag_table_source.yaml
@@ -299,7 +299,6 @@ diag_table:
         fields:
             tob: # Sea Water Potential Temperature at Sea Floor
             mlotst: # Mixed layer depth (delta rho = 0.03) MLD_003
-            e_D: # Interface Height above the Seafloor (m)
             net_heat_coupler: # Surface ocean heat flux from SW+LW+latent+sensible+seaice_melt_heat (via the coupler)
             heat_content_lrunoff: # Heat content (relative to 0C) of liquid runoff into ocean
             Heat_PmE: # Heat flux into ocean from mass flux into ocean
@@ -316,7 +315,7 @@ diag_table:
             output_freq_units: days  # time units for output: years, months, days, hours, minutes, or seconds
             reduction_method: max # mean, snap, rms, pow##, min, max, or diurnal##
         fields:
-            e_D: # Interface Height above the Seafloor (m)
+            tob: # Sea Water Potential Temperature at Sea Floor
             tos: # Sea Surface Temperature
 
     'daily 2D min fields':
@@ -327,6 +326,7 @@ diag_table:
             output_freq_units: days  # time units for output: years, months, days, hours, minutes, or seconds
             reduction_method: min # mean, snap, rms, pow##, min, max, or diurnal##
         fields:
+            tob: # Sea Water Potential Temperature at Sea Floor
             tos: # Sea Surface Temperature
 
     'daily scalar timeseries':

--- a/diag_table_source.yaml
+++ b/diag_table_source.yaml
@@ -44,7 +44,7 @@ global_defaults:
     time_axis_units: days  # time units for the output file time axis: years, months, days, hours, minutes, or seconds
     time_axis_name: time  # must be "time" (case-insensitive)
     new_file_freq: 1  # optional integer: frequency (in new_file_freq_units) for closing the existing file, and creating a new file
-    new_file_freq_units: months  # time units for new_file_freq: years, months, days, hours, minutes, or seconds (optional; required if and only if new_file_freq specified)
+    new_file_freq_units: years  # time units for new_file_freq: years, months, days, hours, minutes, or seconds (optional; required if and only if new_file_freq specified)
     start_time:  # Time to start the file for the first time. The format of this string is the same as base_date (optional; requires new_file_freq, new_file_freq_units)
     file_duration:  # integer: How long file should receive data after start time (optional; requires new_file_freq, new_file_freq_units, start_time)
     file_duration_units:  # units for file_duration: years, months, days, hours, minutes, or seconds (optional; required if and only if file_duration specified)
@@ -73,7 +73,7 @@ global_defaults:
 # extra things for constructing filename:
     file_name_dimension: 3d  # descriptor for filename, e.g. 3d, 2d, scalar
     file_name_prefix: access-om3.mom6
-    file_name_date: "%4yr%2mo"  # "%4yr%2mo" # run date/time of file opening; format: %, 1 digit (#digits), one of (yr, mo, dy, hr, mi, sc); date/time components will be separated by _ in filename.
+    file_name_date: "%4yr" # run date/time of file opening; format: %, 1 digit (#digits), one of (yr, mo, dy, hr, mi, sc); date/time components will be separated by _ in filename.
     file_name_separator: "."  # used to separate filename components; best not to use "_" to avoid confusion with fields and dates
     file_name_omit_empty: true  # whether to omit empty filename components to avoid duplicate file_name_separator
     file_name_substitutions:  # string replacements for filename components

--- a/docs/available_diags.000000
+++ b/docs/available_diags.000000
@@ -1586,7 +1586,7 @@
     ! units: m
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {e,e_xyave}
-"e_D"  [Used]
+"e_D"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
     ! long_name: Interface Height above the Seafloor
     ! units: m


### PR DESCRIPTION
**1. Summary**:
<!-- summarise the changes -->
Updated the MOM diagnostic table configuration to output annual files instead of one file per month.

**2. Issues Addressed:**
<!-- Add links to github issue(s) this is related to -->
- https://github.com/ACCESS-NRI/access-om3-configs/issues/498

