### PR TITLE
Turn on cice grid output file

### DIFF
--- a/ice_in
+++ b/ice_in
@@ -24,6 +24,7 @@
   grid_ice = "B"
   grid_ocn = "A"
   grid_type = "tripole"
+  grid_outfile = .true.
   kcatbound = 0
   kmt_file = "./INPUT/kmt.nc"
   nblyr = 1


### PR DESCRIPTION
<!-- use these prompts for changes to configuration branhces, skip them for main branch changes -->
**1. Summary**:

What has changed?

Enabled seperate cice grid output file in latest builds

Why was this done?

This is easier to work with and reduces duplication compared to storing this in the other history files

**2. Issues Addressed:**
<!-- Add links to github issue(s) this is related to -->
#470 

**3. Depedencies (e.g. on payu, model or om3-scripts)**

This change requires changes to (note required version where true):
- [ ] payu:
- [x] access-om3: 2025.05.001
- [ ] om3-scripts:
2025.05.001 is the first model build with this feature
**4. Ad-hoc Testing**

What ad-hoc testing was done? How are you convinced this change is correct (plots are good)?

- Ran for one day, `access-om3.cice_grid.nc` file was created

**5. CI Testing**
<!-- Has the CI-testing been run? -->
- [ ] `!test repro` has been run

**6. Reproducibility**

Is this reproducible with the previous commit? (If not, why not?)
- [ ] Yes
- [ ] No - `!test repro commit` has been run. <!-- add detail below for why it's answer changing --> 

**7. Documentation**
<!--Does this impact documentation? Has the wiki been updated? Have the `docs/MOM_*` files been updated ?-->

The docs folder has been updated with output from running the model?
- [x] Yes
- [ ] N/A

A PR has been created for updating the documentation?
- [x] Yes: [<!--link-->](https://github.com/ACCESS-NRI/access-om3-configs/pull/567)
- [ ] N/A

**8. Formatting**
<!-- Are changes to MOM_input in the same order as docs/MOM_parameter_docs.short? -->

Changes to MOM_input have been copied from model output in docs/MOM_parameter_docs.short?
- [ ] Yes
- [x] N/A

**9. Merge Strategy**
<!-- What is the planned merge strategy (Merge commit, Rebase and merge, or squash) ?
If not squash, link to the related issue in the commit descriptions -->

- [ ] Merge commit
- [ ] Rebase and merge
- [x] Squash
