### PR TITLE
`MC_100km_jra_ryf+wombatlite`: Update to prerelease with gtracers dev-2025.06.002

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -27,19 +27,19 @@ input:
     - /g/data/vk83/configurations/inputs/access-om3/share/grids/global.100km/2020.10.22/topog.nc
     - /g/data/vk83/configurations/inputs/access-om3/mom/grids/mosaic/global.100km/2020.05.30/ocean_hgrid.nc
     - /g/data/vk83/configurations/inputs/access-om3/mom/grids/mosaic/global.100km/2020.05.30/ocean_mosaic.nc
-    - /g/data/vk83/configurations/inputs/access-om3/mom/grids/mosaic/global.100km/2024.05.08/grid_spec.nc
+    - /g/data/vk83/prerelease/configurations/inputs/access-om3/mom/grids/mosaic/share/2024.05.08/grid_spec.nc
     - /g/data/vk83/prerelease/configurations/inputs/access-om3/mom/grids/vertical/share/2025.03.12/ocean_vgrid.nc
     - /g/data/vk83/configurations/inputs/access-om3/mom/initial_conditions/global.100km/2020.10.22/ocean_temp_salt.res.nc
     - /g/data/vk83/configurations/inputs/access-om3/mom/surface_salt_restoring/global.100km/2020.05.30/salt_sfc_restore.nc
     - /g/data/vk83/configurations/inputs/access-om3/cice/grids/global.100km/2024.05.14/kmt.nc
     - /g/data/vk83/configurations/inputs/access-om3/cice/initial_conditions/global.100km/2023.07.28/iced.1900-01-01-10800.nc
-    - /g/data/vk83/configurations/inputs/access-om3/wombat/forcing/global.100km/2022.02.24/dust.nc
-    - /g/data/vk83/configurations/inputs/access-om3/wombat/initial_conditions/global.100km/2021.06.07/FEMIP_model_median_iron_2016_fillmiss.nc
-    - /g/data/vk83/configurations/inputs/access-om3/wombat/initial_conditions/global.100km/2024.04.02/GLODAPv2.2016b.NO3_fillmiss.nc
-    - /g/data/vk83/configurations/inputs/access-om3/wombat/initial_conditions/global.100km/2024.04.02/GLODAPv2.2016b.oxygen_fillmiss.nc
-    - /g/data/vk83/configurations/inputs/access-om3/wombat/initial_conditions/global.100km/2024.04.02/GLODAPv2.2016b.PI_TCO2_fillmiss.nc
-    - /g/data/vk83/configurations/inputs/access-om3/wombat/initial_conditions/global.100km/2024.04.02/GLODAPv2.2016b.TAlk_fillmiss.nc
-    - /g/data/vk83/configurations/inputs/access-om3/wombat/initial_conditions/global.100km/2024.04.02/GLODAPv2.2016b.TCO2_fillmiss.nc
+    - /g/data/vk83/prerelease/configurations/inputs/access-om3/wombat/forcing/global.100km/2025.06.24/dust.nc
+    - /g/data/vk83/prerelease/configurations/inputs/access-om3/wombat/initial_conditions/share/2021.06.07/FEMIP_model_median_iron_2016_fillmiss.nc
+    - /g/data/vk83/prerelease/configurations/inputs/access-om3/wombat/initial_conditions/share/2024.04.02/GLODAPv2.2016b.NO3_fillmiss.nc
+    - /g/data/vk83/prerelease/configurations/inputs/access-om3/wombat/initial_conditions/share/2024.04.02/GLODAPv2.2016b.oxygen_fillmiss.nc
+    - /g/data/vk83/prerelease/configurations/inputs/access-om3/wombat/initial_conditions/share/2024.04.02/GLODAPv2.2016b.PI_TCO2_fillmiss.nc
+    - /g/data/vk83/prerelease/configurations/inputs/access-om3/wombat/initial_conditions/share/2024.04.02/GLODAPv2.2016b.TAlk_fillmiss.nc
+    - /g/data/vk83/prerelease/configurations/inputs/access-om3/wombat/initial_conditions/share/2024.04.02/GLODAPv2.2016b.TCO2_fillmiss.nc
     - /g/data/vk83/prerelease/configurations/inputs/access-om3/wombat/initial_conditions/global.100km/2025.06.06/init_ocean_wombatlite.res.nc
     - /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data
  
@@ -54,9 +54,9 @@ userscripts:
 
 modules:
     use:
-        - /g/data/vk83/modules
+        - /g/data/vk83/prerelease/modules
     load:
-        - access-om3/2025.05.001
+        - access-om3/pr116-3 # access-om3/2025.05.001 with gtracers updated to dev-2025.06.002
         - nco/5.0.5
 
 payu_minimum_version: 1.1.6

--- a/data_table
+++ b/data_table
@@ -3,6 +3,6 @@
 # gridname | fieldname_code            | fieldname_file | file_name                                      | ongrid    | factor
 # ---------------------------------------------------------------------------------------------------------------------------------
 "OCN"      , "co2_flux_pcair_atm"      , ""             , ""                                             , "none"    , 315.165e-06
-"OCN"      , "co2_nat_flux_pcair_atm"  , ""             , ""                                             , "none"    , 284.262e-06
+"OCN"      , "co2_pre_flux_pcair_atm"  , ""             , ""                                             , "none"    , 284.262e-06
 "OCN"      , "o2_flux_pcair_atm"       , ""             , ""                                             , "none"    , 0.21
 "OCN"      , "dry_dep_fe_flux_ice_ocn" , "dust"         , "./INPUT/dust.nc"                              , "none"    , -1.0e-06

--- a/input.nml
+++ b/input.nml
@@ -12,7 +12,10 @@
 /
 
 &generic_wombatlite_nml
-    co2_calc='ocmip2'
+    co2_calc='mocsy'
+    do_caco3_dynamics=.true.
+    do_burial=.false.
+    do_conserve_tracers=.false.
 /
 
 &fms_nml

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -2,7 +2,7 @@ format: yamanifest
 version: 1.0
 ---
 work/access-om3-MOM6-CICE6:
-  fullpath: /g/data/vk83/apps/spack/0.22/release/linux-rocky8-x86_64_v4/oneapi-2025.0.4/access3-2025.03.1-3joxy64tlxmkt66pxhpw6gydxfnd7fvl/bin/access-om3-MOM6-CICE6
+  fullpath: /g/data/vk83/prerelease/apps/spack/0.22/release/linux-rocky8-x86_64_v4/oneapi-2025.0.4/access3-2025.03.1-d5ykvk3vzvurvinx2kjonqzbkitecnrp/bin/access-om3-MOM6-CICE6
   hashes:
-    binhash: 37359bf2f545a1dabd018143cbcde32a
-    md5: 6caef5a9389009d920c5ff90f5b13867
+    binhash: 855c6fb8d146ce00ad54cde4c688bead
+    md5: 7e1edb2513cfe85a1b4fb88374670e61

--- a/manifests/input.yaml
+++ b/manifests/input.yaml
@@ -2,34 +2,34 @@ format: yamanifest
 version: 1.0
 ---
 work/INPUT/FEMIP_model_median_iron_2016_fillmiss.nc:
-  fullpath: /g/data/vk83/configurations/inputs/access-om3/wombat/initial_conditions/global.100km/2021.06.07/FEMIP_model_median_iron_2016_fillmiss.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-om3/wombat/initial_conditions/share/2021.06.07/FEMIP_model_median_iron_2016_fillmiss.nc
   hashes:
-    binhash: 5ec9969fee40589a5083b438657de476
+    binhash: f7faffb810e0612d523da6c5ae669db4
     md5: b81d7ee79a6ca30bfd2e6ccc49874267
 work/INPUT/GLODAPv2.2016b.NO3_fillmiss.nc:
-  fullpath: /g/data/vk83/configurations/inputs/access-om3/wombat/initial_conditions/global.100km/2024.04.02/GLODAPv2.2016b.NO3_fillmiss.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-om3/wombat/initial_conditions/share/2024.04.02/GLODAPv2.2016b.NO3_fillmiss.nc
   hashes:
-    binhash: ae70284ca4d9849e83de9ff5c30a2d61
+    binhash: 88d5d6cb1fc3f709ee473ad9747f9ed2
     md5: c5afb27948688743858ef966be81ec2e
 work/INPUT/GLODAPv2.2016b.PI_TCO2_fillmiss.nc:
-  fullpath: /g/data/vk83/configurations/inputs/access-om3/wombat/initial_conditions/global.100km/2024.04.02/GLODAPv2.2016b.PI_TCO2_fillmiss.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-om3/wombat/initial_conditions/share/2024.04.02/GLODAPv2.2016b.PI_TCO2_fillmiss.nc
   hashes:
-    binhash: 6237599e013cc432a62db14c768e9b8b
+    binhash: 765758579f17ad65b33401d70ccae270
     md5: 0aa9f4a37ff5f01cc180d85305815829
 work/INPUT/GLODAPv2.2016b.TAlk_fillmiss.nc:
-  fullpath: /g/data/vk83/configurations/inputs/access-om3/wombat/initial_conditions/global.100km/2024.04.02/GLODAPv2.2016b.TAlk_fillmiss.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-om3/wombat/initial_conditions/share/2024.04.02/GLODAPv2.2016b.TAlk_fillmiss.nc
   hashes:
-    binhash: b73c5a628d1a5f3a2818c3061e3fddd4
+    binhash: 4f23e10845529b52a4cfe13cbe864a24
     md5: b84783902f2bc82711496cca49e78a16
 work/INPUT/GLODAPv2.2016b.TCO2_fillmiss.nc:
-  fullpath: /g/data/vk83/configurations/inputs/access-om3/wombat/initial_conditions/global.100km/2024.04.02/GLODAPv2.2016b.TCO2_fillmiss.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-om3/wombat/initial_conditions/share/2024.04.02/GLODAPv2.2016b.TCO2_fillmiss.nc
   hashes:
-    binhash: 39208f747b5bd9792579ede649126eb0
+    binhash: 3d35aa452c66bdf78d0ec18607359ceb
     md5: 9f8ba1f96551df518e86e510a765311e
 work/INPUT/GLODAPv2.2016b.oxygen_fillmiss.nc:
-  fullpath: /g/data/vk83/configurations/inputs/access-om3/wombat/initial_conditions/global.100km/2024.04.02/GLODAPv2.2016b.oxygen_fillmiss.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-om3/wombat/initial_conditions/share/2024.04.02/GLODAPv2.2016b.oxygen_fillmiss.nc
   hashes:
-    binhash: 765d3d8d4d92fd4c98f25a1ca2e8a914
+    binhash: 69305dfb06508866f7e9b4ab49b3ae9a
     md5: 1abf34fa578d0a589615d5e9a0e465ac
 work/INPUT/JRA55do-datm-ESMFmesh.nc:
   fullpath: /g/data/vk83/configurations/inputs/access-om3/share/meshes/share/2024.09.16/JRA55do-datm-ESMFmesh.nc
@@ -112,14 +112,14 @@ work/INPUT/access-om2-100km-nomask-ESMFmesh.nc:
     binhash: 38605aedd850ec5c9d208258f2030166
     md5: 9b7120a42b5cb587492e7c31791eb549
 work/INPUT/dust.nc:
-  fullpath: /g/data/vk83/configurations/inputs/access-om3/wombat/forcing/global.100km/2022.02.24/dust.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-om3/wombat/forcing/global.100km/2025.06.24/dust.nc
   hashes:
-    binhash: 27b85ba44177e8fdeea765179841c73c
-    md5: b66d8d72cd49801a74da90b211e8dd21
+    binhash: 8e52393730c7ad07cf63826755a4ba79
+    md5: f95a4e3af87570b3760cf228b1aeb5a4
 work/INPUT/grid_spec.nc:
-  fullpath: /g/data/vk83/configurations/inputs/access-om3/mom/grids/mosaic/global.100km/2024.05.08/grid_spec.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-om3/mom/grids/mosaic/share/2024.05.08/grid_spec.nc
   hashes:
-    binhash: a2c6813be9a75777ff6318170e5985ad
+    binhash: 2fb8d504904e652a37185852f17dbcd4
     md5: 709268cd891e6f0e827f6de0249f1a3d
 work/INPUT/iced.1900-01-01-10800.nc:
   fullpath: /g/data/vk83/configurations/inputs/access-om3/cice/initial_conditions/global.100km/2023.07.28/iced.1900-01-01-10800.nc


### PR DESCRIPTION
<!-- use these prompts for changes to configuration branhces, skip them for main branch changes -->
**1. Summary**:

This PR updates to using the same prerelease/configuration as the new 25km+WOMBATlite configuration. The prerelease is the same as `access-om3/2025.05.001` but with `access-generic-tracers` updated to `dev-2025.06.002`. The update to `access-generic-tracers` includes:
- Removing limiting on wsink -  see https://github.com/ACCESS-NRI/GFDL-generic-tracers/pull/34
- Fixing up non-conservation error reporting - see https://github.com/ACCESS-NRI/GFDL-generic-tracers/pull/35
  
Additional updates made to the configuration in this PR:
- Use MOCSY for co2 calculation
- Change "co2_nat_flux" to "co2_pre_flux" in data_table
- Update to dust.nc input with provenance and extrapolation
- Update input files to share location (so same files are used for 100km and 25km configurations)

**3. Depedencies (e.g. on payu, model or om3-scripts)**

This change requires changes to (note required version where true):
- [ ] payu:
- [x] access-om3 (currently `access-om3/pr116-3`):
- [ ] om3-scripts:
<!-- Describe and link to the related changes to dependencies -->

**4. Ad-hoc Testing**

The configuration actually crashes within the first year due to non-conservation of C. I aim to get this fixed up before merging, but I'm opening this PR now to make sharing with others easier.

**5. CI Testing**
<!-- Has the CI-testing been run? -->
- [ ] `!test repro` has been run

**6. Reproducibility**

Is this reproducible with the previous commit? (If not, why not?)
- [ ] Yes
- [ ] No - `!test repro commit` has been run. <!-- add detail below for why it's answer changing --> 

**7. Documentation**
<!--Does this impact documentation? Has the wiki been updated? Have the `docs/MOM_*` files been updated ?-->

The docs folder has been updated with output from running the model?
- [ ] Yes
- [x] N/A

A PR has been created for updating the documentation?
- [ ] Yes: <!--link-->
- [x] N/A

**8. Formatting**
<!-- Are changes to MOM_input in the same order as docs/MOM_parameter_docs.short? -->

Changes to MOM_input have been copied from model output in docs/MOM_parameter_docs.short?
- [ ] Yes
- [x] N/A

**9. Merge Strategy**
<!-- What is the planned merge strategy (Merge commit, Rebase and merge, or squash) ?
If not squash, link to the related issue in the commit descriptions -->

- [ ] Merge commit
- [ ] Rebase and merge
- [x] Squash