### PR TITLE
Set payu minimum version

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -70,4 +70,4 @@ userscripts:
     archive: /usr/bin/bash /g/data/vk83/apps/om3-scripts/payu_config/archive.sh
 
 restart_freq: 1YS
-payu_minimum_version: 1.1.6
+payu_minimum_version: 1.1.7


### PR DESCRIPTION
Updating the payu minimum version.

1.17 includes date base restart pruning, and automated committing of MOM_paramater_doc files (https://github.com/payu-org/payu/releases/tag/1.1.7)