### PR TITLE
Update model-config-tests version

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -17,7 +17,7 @@
         "release-MC_25km_jra_ryf": { },
         "release-MCW_100km_jra_ryf": { },
         "release-.*": {
-            "model-config-tests-version": "0.1.0",
+            "model-config-tests-version": "0.2.0",
             "payu-version": "1.1.7"
         }
     },
@@ -41,7 +41,7 @@
             "markers": "repro"
         },
         "release-.*": {
-            "model-config-tests-version": "0.1.0",
+            "model-config-tests-version": "0.2.0",
             "payu-version": "1.1.7"
         }
     },


### PR DESCRIPTION
We need to newer version to set the runtime correctly (https://github.com/ACCESS-NRI/model-config-tests/commit/2d000c586ef2340ffdb62f21b31527539147aeed)