### PR TITLE
Style citations

### DIFF
--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -63,6 +63,7 @@ plugins:
   - macros
   - bibtex:
       bib_file: references.bib
+      csl_file: https://raw.githubusercontent.com/citation-style-language/styles/26eccff9e537f71494a4da7b91afac1adf571dc9/apa.csl
   - events:
       events_dir: community_resources/events/events
 

--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -2,4 +2,5 @@ mkdocs-material==9.6.11
 mkdocs-git-revision-date-localized-plugin==1.2.0
 mkdocs-macros-plugin==1.0.4
 mkdocs-bibtex==4.2.5
+pypandoc==1.15
 git+https://github.com/rbeucher/mkdocs_events_plugin.git

--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -1,6 +1,6 @@
 mkdocs-material==9.6.11
 mkdocs-git-revision-date-localized-plugin==1.2.0
 mkdocs-macros-plugin==1.0.4
-mkdocs-bibtex==4.2.5
+mkdocs-bibtex==4.4.0
 pypandoc==1.15
 git+https://github.com/rbeucher/mkdocs_events_plugin.git

--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -2,5 +2,5 @@ mkdocs-material==9.6.11
 mkdocs-git-revision-date-localized-plugin==1.2.0
 mkdocs-macros-plugin==1.0.4
 mkdocs-bibtex==4.4.0
-pypandoc==1.15
+pypandoc_binary==1.15
 git+https://github.com/rbeucher/mkdocs_events_plugin.git


### PR DESCRIPTION
@minghangli-uni 

Added `csl_file` option to bibtex plugin to style citations. 
The csl_file is taken from the [apa.csl](https://raw.githubusercontent.com/citation-style-language/styles/26eccff9e537f71494a4da7b91afac1adf571dc9/apa.csl), which is a "Author-Date" format CSL.

This means that citations written as:
```markdown
[@citation-key]
```

Will be rendered as:
> (FIRST-AUTHOR et al., YEAR) <sup>1</sup>

instead of the previous:
> <sup>1</sup>
