### PR TITLE
Add data_table with fields for co2 and o2 fluxes

### DIFF
--- a/data_table
+++ b/data_table
@@ -1,0 +1,7 @@
+# MOM/FMS data table
+#
+# gridname | fieldname_code           | fieldname_file | file_name | ongrid  | factor
+# ----------------------------------------------------------------------------------------
+"OCN"      , "co2_flux_pcair_atm"     , ""              , ""       , "none" , 315.165e-06
+"OCN"      , "co2_nat_flux_pcair_atm" , ""              , ""       , "none" , 284.262e-06
+"OCN"      , "o2_flux_pcair_atm"      , ""              , ""       , "none" , 0.21


### PR DESCRIPTION
This PR adds a `data_table` with fields for co2 and o2 fluxes.

@helenmacdonald I recall Lizzie has already created the dust input on the correct grid? Do you have access to Lizzie’s dust file and if so can you add it?

You'll need to add the path to the file to the `config.yaml` and the following to the `data_table`:

```
"OCN", "dry_dep_fe_flux_ice_ocn", "dust", "./INPUT/dust.nc", "none", -1.0e-06
```

If it's not ready to go, we could just merge this and add dust forcing later