### PR TITLE
Add dust forcing to data_table

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -33,7 +33,7 @@ input:
     - /g/data/ol01/ee8016/regional_wombat/ocean_mosaic.nc
     - /g/data/ol01/ee8016/regional_wombat/access-rom3-ESMFmesh.nc
     - /g/data/ol01/ee8016/regional_wombat/access-rom3-nomask-ESMFmesh.nc
-    - /g/data/ol01/ee8016/regional_wombat/modifiedfiles/dust_model_year.nc
+    - /g/data/ol01/ee8016/regional_wombat/dust_DS.nc
     - /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/
 collate: false
 runlog: false

--- a/data_table
+++ b/data_table
@@ -1,7 +1,8 @@
 # MOM/FMS data table
 #
-# gridname | fieldname_code           | fieldname_file | file_name | ongrid  | factor
-# ----------------------------------------------------------------------------------------
-"OCN"      , "co2_flux_pcair_atm"     , ""              , ""       , "none" , 315.165e-06
-"OCN"      , "co2_nat_flux_pcair_atm" , ""              , ""       , "none" , 284.262e-06
-"OCN"      , "o2_flux_pcair_atm"      , ""              , ""       , "none" , 0.21
+# gridname | fieldname_code           | fieldname_file | file_name           | ongrid | factor
+# -------------------------------------------------------------------------------------------------
+"OCN"      , "co2_flux_pcair_atm"     , ""             , ""                  , "none" , 315.165e-06
+"OCN"      , "co2_nat_flux_pcair_atm" , ""             , ""                  , "none" , 284.262e-06
+"OCN"      , "o2_flux_pcair_atm"      , ""             , ""                  , "none" , 0.21
+"OCN"      , "dry_dep_fe_flux_ice_ocn", "dust"         , "./INPUT/dust_DS.nc", "none" , -1.0e-06


### PR DESCRIPTION
New dust forcing file is generated using https://github.com/ACCESS-NRI/om3-scripts/blob/main/wombat_ic_generation/regrid_forcing.py

```
$ module use /g/data/xp65/public/modules
$ module load conda/analysis3-25.06
$ python3 /g/data/vk83/apps/om3-scripts/wombat_ic_generation/regrid_forcing.py --forcing-filename=/g/data/ik11/inputs/BGC/input/dust.nc --hgrid-filename=/g/data/ol01/ee8016/regional_wombat/hgrid.nc --output-filename=/g/data/ol01/ee8016/regional_wombat/modifiedfiles/dust_DS.nc --mask-filename=/g/data/ik11/inputs/BGC/input/dust_mask.nc --lon-name=x_T --lat-name=y_T
```