### PR TITLE
Include stubs

### DIFF
--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -55,6 +55,17 @@ theme:
 copyright: Copyright &copy; 2025 ACCESS-NRI
 
 plugins:
+  - include-configuration-stubs:
+      repo: ACCESS-NRI/access-om3-configs
+      main_website:
+        pattern: ""
+        ref_type: branch
+      preview_website:
+        pattern: "dev-MC_25km_jra_ryf"
+        ref_type: branch
+      stubs_parent_url: pages/configurations
+      stubs_nav_path: Configurations
+
   - git-revision-date-localized:
       type: date
       enable_creation_date: false

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -58,10 +58,10 @@ plugins:
   - include-configuration-stubs:
       repo: ACCESS-NRI/access-om3-configs
       main_website:
-        pattern: ""
+        pattern: "dev-* release-*"
         ref_type: branch
       preview_website:
-        pattern: "dev-MC_25km_jra_ryf"
+        pattern: ""
         ref_type: branch
       stubs_parent_url: pages/configurations
       stubs_nav_path: Configurations

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -65,6 +65,7 @@ plugins:
         ref_type: branch
       stubs_parent_url: pages/configurations
       stubs_nav_path: Configurations
+      stubs_dir: documentation/stub
 
   - git-revision-date-localized:
       type: date

--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -4,3 +4,4 @@ mkdocs-macros-plugin==1.0.4
 mkdocs-bibtex==4.4.0
 pypandoc_binary==1.15
 git+https://github.com/rbeucher/mkdocs_events_plugin.git
+git+https://github.com/ACCESS-NRI/mkdocs_include_configuration_stubs_plugin.git


### PR DESCRIPTION
## Overview
 - [x] Added [mkdocs-include-configuration-stubs-plugin](https://github.com/ACCESS-NRI/mkdocs_include_configuration_stubs_plugin?tab=readme-ov-file#mkdocs-include-configuration-stubs-plugin) to the [requirements.txt](https://github.com/ACCESS-NRI/access-om3-configs/blob/davide/527-include_stubs/documentation/requirements.txt)
 - [x] Added the include-configuration-stubs plugin to the [`mkdocs.yaml`]:
    https://github.com/ACCESS-NRI/access-om3-configs/blob/f5576932a5300585ef050b1c5cba2f9596390631/documentation/mkdocs.yml#L57-L70

### Plugin settings
The plugin settings will need adjustments, so we should discuss below what are the correct settings based on your needs.

For details, please read the [mkdocs-include-configuration-stubs-plugin documentation](https://github.com/ACCESS-NRI/mkdocs_include_configuration_stubs_plugin?tab=readme-ov-file#mkdocs-include-configuration-stubs-plugin) and please let me know if any part is missing or unclear.
Currently writing more content in the [MkDocs Wrapper section](https://github.com/ACCESS-NRI/mkdocs_include_configuration_stubs_plugin?tab=readme-ov-file#mkdocs-wrapper).

> [!CAUTION]
> As long as this PR is not merged (or closed), other PR previews will not work (this is a "bug" already fixed but this repo's documentation build workflow needs updating).
> Therefore, it should be possibly merged quickly.