### PR TITLE
Restart repro revisited

### DIFF
--- a/MOM_input
+++ b/MOM_input
@@ -141,6 +141,12 @@ DTFREEZE_DP = -7.75E-08         !   [degC Pa-1] default = 0.0
                                 ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
+! === module MOM_restart ===
+RESTART_UNSIGNED_ZEROS = True   !   [Boolean] default = False
+                                ! If true, convert any negative zeros that would be written to the restart file
+                                ! into ordinary unsigned zeros.  This does not change answers, but it can be
+                                ! helpful in comparing restart files after grid rotation, for example.
+
 ! === module MOM_tracer_flow_control ===
 USE_IDEAL_AGE_TRACER = True     !   [Boolean] default = False
                                 ! If true, use the ideal_age_example tracer package.

--- a/MOM_input
+++ b/MOM_input
@@ -141,12 +141,6 @@ DTFREEZE_DP = -7.75E-08         !   [degC Pa-1] default = 0.0
                                 ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
-! === module MOM_restart ===
-RESTART_UNSIGNED_ZEROS = True   !   [Boolean] default = False
-                                ! If true, convert any negative zeros that would be written to the restart file
-                                ! into ordinary unsigned zeros.  This does not change answers, but it can be
-                                ! helpful in comparing restart files after grid rotation, for example.
-
 ! === module MOM_tracer_flow_control ===
 USE_IDEAL_AGE_TRACER = True     !   [Boolean] default = False
                                 ! If true, use the ideal_age_example tracer package.

--- a/config.yaml
+++ b/config.yaml
@@ -45,7 +45,7 @@ modules:
     use:
         - /g/data/vk83/prerelease/modules
     load:
-        - access-om3/pr140-2
+        - access-om3/pr138-15
         - nco/5.0.5
 
 payu_minimum_version: 1.1.6

--- a/config.yaml
+++ b/config.yaml
@@ -45,7 +45,7 @@ modules:
     use:
         - /g/data/vk83/prerelease/modules
     load:
-        - access-om3/pr138-15
+        - access-om3/pr138-17
         - nco/5.0.5
 
 payu_minimum_version: 1.1.6

--- a/config.yaml
+++ b/config.yaml
@@ -43,9 +43,9 @@ userscripts:
 
 modules:
     use:
-        - /g/data/vk83/modules
+        - /g/data/vk83/prerelease/modules
     load:
-        - access-om3/2025.05.001
+        - access-om3/pr140-2
         - nco/5.0.5
 
 payu_minimum_version: 1.1.6

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -2,7 +2,7 @@ format: yamanifest
 version: 1.0
 ---
 work/access-om3-MOM6-CICE6:
-  fullpath: /g/data/vk83/prerelease/apps/spack/0.22/release/linux-rocky8-x86_64_v4/oneapi-2025.0.4/access3-2025.03.1-tp2cuvmai3pxkopdii6ohjavpcygno4q/bin/access-om3-MOM6-CICE6
+  fullpath: /g/data/vk83/prerelease/apps/spack/0.22/release/linux-rocky8-x86_64_v4/oneapi-2025.2.0/access3-2025.08.000-otepta6lr7swzrvutrrdi4altbl7y4v7/bin/access-om3-MOM6-CICE6
   hashes:
-    binhash: e305b66f75619b572560e757e66a1935
-    md5: 414836c974d3e9cc71ecaa9d706c0bbf
+    binhash: 01c3bb6b429ceecb2fd26b3438a546e7
+    md5: 2258a1cfc4a4d8c390da818ded27551b

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -2,7 +2,7 @@ format: yamanifest
 version: 1.0
 ---
 work/access-om3-MOM6-CICE6:
-  fullpath: /g/data/vk83/prerelease/apps/spack/0.22/release/linux-rocky8-x86_64_v4/oneapi-2025.2.0/access3-2025.08.000-otepta6lr7swzrvutrrdi4altbl7y4v7/bin/access-om3-MOM6-CICE6
+  fullpath: /g/data/vk83/prerelease/apps/spack/0.22/release/linux-rocky8-x86_64_v4/oneapi-2025.2.0/access3-2025.08.000-gxujedudcdouhy4zm2kk3nobakxbrmbw/bin/access-om3-MOM6-CICE6
   hashes:
-    binhash: 01c3bb6b429ceecb2fd26b3438a546e7
-    md5: 2258a1cfc4a4d8c390da818ded27551b
+    binhash: b44a0510f359020ff2e499617bef06bb
+    md5: 7fbaa6709ecabb2259bca74d29cfa01e

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -2,7 +2,7 @@ format: yamanifest
 version: 1.0
 ---
 work/access-om3-MOM6-CICE6:
-  fullpath: /g/data/vk83/apps/spack/0.22/release/linux-rocky8-x86_64_v4/oneapi-2025.0.4/access3-2025.03.1-3joxy64tlxmkt66pxhpw6gydxfnd7fvl/bin/access-om3-MOM6-CICE6
+  fullpath: /g/data/vk83/prerelease/apps/spack/0.22/release/linux-rocky8-x86_64_v4/oneapi-2025.0.4/access3-2025.03.1-tp2cuvmai3pxkopdii6ohjavpcygno4q/bin/access-om3-MOM6-CICE6
   hashes:
-    binhash: 37359bf2f545a1dabd018143cbcde32a
-    md5: 6caef5a9389009d920c5ff90f5b13867
+    binhash: e305b66f75619b572560e757e66a1935
+    md5: 414836c974d3e9cc71ecaa9d706c0bbf


### PR DESCRIPTION
We have been compiling MOM in asymmetric memory mode in ACCESS-OM3 due to issues with restart reproducibility in symmetric memory mode. We never completely got to the root cause of the issue but it appeared to be related to the specific set of parameter values being used in the 100km configs (see [here](https://github.com/ACCESS-NRI/access-om3-configs/issues/447) and [here](https://github.com/mom-ocean/MOM6/issues/1660)). Our 25km configuration does not have the issue.

A lot has changed in MOM since we last tested the issue and my local testing suggests that the issue no longer exists. This PR is to test/document.