### PR TITLE
Track down the slow runtime performance starting from srcatch

### DIFF
--- a/MOM_input
+++ b/MOM_input
@@ -707,6 +707,10 @@ CHECK_DIFFUSIVE_CFL = True      !   [Boolean] default = False
                                 ! If true, use enough iterations the diffusion to ensure that the diffusive
                                 ! equivalent of the CFL limit is not violated.  If false, always use the greater
                                 ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
+MAX_TR_DIFFUSION_CFL = 2.0      !   [nondim] default = -1.0
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers

--- a/docs/MOM_parameter_doc.all
+++ b/docs/MOM_parameter_doc.all
@@ -2270,7 +2270,7 @@ CHECK_DIFFUSIVE_CFL = True      !   [Boolean] default = False
                                 ! If true, use enough iterations the diffusion to ensure that the diffusive
                                 ! equivalent of the CFL limit is not violated.  If false, always use the greater
                                 ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
-MAX_TR_DIFFUSION_CFL = -1.0     !   [nondim] default = -1.0
+MAX_TR_DIFFUSION_CFL = 2.0      !   [nondim] default = -1.0
                                 ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
                                 ! diffusive CFL locally at or below this value.  The number of diffusive
                                 ! iterations is often this value or the next greater integer.

--- a/docs/MOM_parameter_doc.short
+++ b/docs/MOM_parameter_doc.short
@@ -679,6 +679,10 @@ CHECK_DIFFUSIVE_CFL = True      !   [Boolean] default = False
                                 ! If true, use enough iterations the diffusion to ensure that the diffusive
                                 ! equivalent of the CFL limit is not violated.  If false, always use the greater
                                 ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
+MAX_TR_DIFFUSION_CFL = 2.0      !   [nondim] default = -1.0
+                                ! If positive, locally limit the along-isopycnal tracer diffusivity to keep the
+                                ! diffusive CFL locally at or below this value.  The number of diffusive
+                                ! iterations is often this value or the next greater integer.
 
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers


### PR DESCRIPTION
<!-- use these prompts for changes to configuration branhces, skip them for main branch changes -->
**1. Summary**:
Improves runtime performance by starting from scratch - setting `MAX_TR_DIFFUSION_CFL = 2.0` instead of the default value of -1.

What has changed?
`MOM_input`

Why was this done?

**2. Issues Addressed:**
<!-- Add links to github issue(s) this is related to -->
- https://github.com/ACCESS-NRI/access-om3-configs/issues/656

**3. Dependencies (e.g. on payu, model or om3-scripts)**

This change requires changes to (note required version where true):
- [ ] payu:
- [ ] access-om3:
- [ ] om3-scripts:
<!-- Describe and link to the related changes to dependencies -->

**4. Ad-hoc Testing**

What ad-hoc testing was done? How are you convinced this change is correct (plots are good)?

**5. CI Testing**
<!-- Has the CI-testing been run? -->
- [ ] `!test repro` has been run

**6. Reproducibility**

Is this reproducible with the previous commit? (If not, why not?)
- [ ] Yes
- [ ] No - `!test repro commit` has been run. <!-- add detail below for why it's answer changing --> 

**7. Documentation**
<!--Does this impact documentation? Has the wiki been updated? Have the `docs/MOM_*` files been updated ?-->

The docs folder has been updated with output from running the model?
- [ ] Yes
- [ ] N/A

A PR has been created for updating the documentation?
- [ ] Yes: <!--link-->
- [ ] N/A

**8. Formatting**
<!-- Are changes to MOM_input in the same order as docs/MOM_parameter_docs.short? -->

Changes to MOM_input have been copied from model output in docs/MOM_parameter_docs.short?
- [ ] Yes
- [ ] N/A

**9. Merge Strategy**
<!-- What is the planned merge strategy (Merge commit, Rebase and merge, or squash) ?
If not squash, link to the related issue in the commit descriptions -->

- [ ] Merge commit
- [ ] Rebase and merge
- [ ] Squash


---

When running with `USE_NEUTRAL_DIFFUSION = True` and `CHECK_DIFFUSIVE_CFL = True`, the model spends a lot of time during the first few months of a cold start doing hundreds / thousands of diffusion sub-iterations perstep due to a very large diffusive CFL. By setting MAX_TR_DIFFUSION_CFL = 2.0 - also the value used in GFDL OM5 configs, runtime improves immediately - `num_itts` below drops to 2 every step during the spin-up.

```
339 NOTE from PE     0: CFL check: num_itts=828  max_CFL= 8.27341E+02
340 NOTE from PE     0: CFL check: num_itts=1004  max_CFL= 1.00368E+03
341 NOTE from PE     0: CFL check: num_itts=799  max_CFL= 7.98389E+02
342 NOTE from PE     0: CFL check: num_itts=606  max_CFL= 6.05614E+02
343 NOTE from PE     0: CFL check: num_itts=539  max_CFL= 5.38568E+02
344 NOTE from PE     0: CFL check: num_itts=479  max_CFL= 4.78931E+02
345 NOTE from PE     0: CFL check: num_itts=449  max_CFL= 4.48010E+02
346 NOTE from PE     0: CFL check: num_itts=426  max_CFL= 4.25313E+02
347 NOTE from PE     0: CFL check: num_itts=406  max_CFL= 4.05444E+02
348 NOTE from PE     0: CFL check: num_itts=388  max_CFL= 3.87245E+02
349 NOTE from PE     0: CFL check: num_itts=368  max_CFL= 3.67035E+02
350 NOTE from PE     0: CFL check: num_itts=346  max_CFL= 3.45876E+02
```

```
752 Model Date: 1900-01-02T00:00:00 wall clock = 2025-08-22T13:50:18 avg dt =   444.76 s/day, dt =   444.76 s/day, rate =     0.53 ypd
753  memory_write: model date = 1900-01-02T00:00:00 memory =      -0.00 MB (highwater)        813.64 MB (usage)
754 Model Date: 1900-01-03T00:00:00 wall clock = 2025-08-22T13:53:45 avg dt =   325.67 s/day, dt =   206.57 s/day, rate =     1.15 ypd
755  memory_write: model date = 1900-01-03T00:00:00 memory =      -0.00 MB (highwater)        813.64 MB (usage)
756 Model Date: 1900-01-04T00:00:00 wall clock = 2025-08-22T13:56:34 avg dt =   273.48 s/day, dt =   169.11 s/day, rate =     1.40 ypd
757  memory_write: model date = 1900-01-04T00:00:00 memory =      -0.00 MB (highwater)        813.64 MB (usage)
758 Model Date: 1900-01-05T00:00:00 wall clock = 2025-08-22T13:59:05 avg dt =   242.91 s/day, dt =   151.21 s/day, rate =     1.57 ypd
759  memory_write: model date = 1900-01-05T00:00:00 memory =      -0.00 MB (highwater)        813.64 MB (usage)
760 Model Date: 1900-01-06T00:00:00 wall clock = 2025-08-22T14:01:23 avg dt =   221.99 s/day, dt =   138.31 s/day, rate =     1.71 ypd
761  memory_write: model date = 1900-01-06T00:00:00 memory =      -0.00 MB (highwater)        813.64 MB (usage)
762 Model Date: 1900-01-07T00:00:00 wall clock = 2025-08-22T14:03:30 avg dt =   206.04 s/day, dt =   126.25 s/day, rate =     1.87 ypd
763  memory_write: model date = 1900-01-07T00:00:00 memory =      -0.00 MB (highwater)        813.64 MB (usage)
764 Model Date: 1900-01-08T00:00:00 wall clock = 2025-08-22T14:05:44 avg dt =   195.83 s/day, dt =   134.61 s/day, rate =     1.76 ypd
765  memory_write: model date = 1900-01-08T00:00:00 memory =      -0.00 MB (highwater)        813.64 MB (usage)
766 Model Date: 1900-01-09T00:00:00 wall clock = 2025-08-22T14:07:41 avg dt =   185.98 s/day, dt =   116.99 s/day, rate =     2.02 ypd
767  memory_write: model date = 1900-01-09T00:00:00 memory =      -0.00 MB (highwater)        813.64 MB (usage)
768 Model Date: 1900-01-10T00:00:00 wall clock = 2025-08-22T14:09:21 avg dt =   176.34 s/day, dt =    99.24 s/day, rate =     2.39 ypd
769  memory_write: model date = 1900-01-10T00:00:00 memory =      -0.00 MB (highwater)        813.64 MB (usage)
770  -------->(med_phases_restart_write) mediating for: 1900  1 10 23 45  0   0
771 (med_io_wopen) creating file access-om3.cpl.r.1900-01-11-00000.nc
772 Model Date: 1900-01-11T00:00:00 wall clock = 2025-08-22T14:14:14 avg dt =   188.09 s/day, dt =   293.79 s/day, rate =     0.81 ypd
773  memory_write: model date = 1900-01-11T00:00:00 memory =      -0.00 MB (highwater)        813.64 MB (usage)
774   SUCCESSFUL TERMINATION OF CMEPS
775 : ===============  # simulated years / cmp-day =        1.260  ===============
```
---

```
339 NOTE from PE     0: CFL check: num_itts=2  max_CFL= 2.00000E+00
340 NOTE from PE     0: CFL check: num_itts=2  max_CFL= 2.00000E+00
341 NOTE from PE     0: CFL check: num_itts=2  max_CFL= 2.00000E+00
342 NOTE from PE     0: CFL check: num_itts=2  max_CFL= 2.00000E+00
343 NOTE from PE     0: CFL check: num_itts=2  max_CFL= 2.00000E+00
344 NOTE from PE     0: CFL check: num_itts=2  max_CFL= 2.00000E+00
345 NOTE from PE     0: CFL check: num_itts=2  max_CFL= 2.00000E+00
346 NOTE from PE     0: CFL check: num_itts=2  max_CFL= 2.00000E+00
347 NOTE from PE     0: CFL check: num_itts=2  max_CFL= 2.00000E+00
348 NOTE from PE     0: CFL check: num_itts=2  max_CFL= 2.00000E+00
349 NOTE from PE     0: CFL check: num_itts=2  max_CFL= 2.00000E+00
350 NOTE from PE     0: CFL check: num_itts=2  max_CFL= 2.00000E+00
```

```
752 Model Date: 1900-01-02T00:00:00 wall clock = 2025-08-22T13:38:49 avg dt =   111.36 s/day, dt =   111.36 s/day, rate =     2.13 ypd
753  memory_write: model date = 1900-01-02T00:00:00 memory =      -0.00 MB (highwater)        829.68 MB (usage)
754 Model Date: 1900-01-03T00:00:00 wall clock = 2025-08-22T13:39:31 avg dt =    76.94 s/day, dt =    42.52 s/day, rate =     5.57 ypd
755  memory_write: model date = 1900-01-03T00:00:00 memory =      -0.00 MB (highwater)        829.68 MB (usage)
756 Model Date: 1900-01-04T00:00:00 wall clock = 2025-08-22T13:40:13 avg dt =    65.36 s/day, dt =    42.21 s/day, rate =     5.61 ypd
757  memory_write: model date = 1900-01-04T00:00:00 memory =      -0.00 MB (highwater)        829.68 MB (usage)
758 Model Date: 1900-01-05T00:00:00 wall clock = 2025-08-22T13:40:56 avg dt =    59.69 s/day, dt =    42.69 s/day, rate =     5.55 ypd
759  memory_write: model date = 1900-01-05T00:00:00 memory =      -0.00 MB (highwater)        829.68 MB (usage)
760 Model Date: 1900-01-06T00:00:00 wall clock = 2025-08-22T13:41:38 avg dt =    56.22 s/day, dt =    42.34 s/day, rate =     5.59 ypd
761  memory_write: model date = 1900-01-06T00:00:00 memory =      -0.00 MB (highwater)        829.68 MB (usage)
762 Model Date: 1900-01-07T00:00:00 wall clock = 2025-08-22T13:42:21 avg dt =    53.91 s/day, dt =    42.36 s/day, rate =     5.59 ypd
763  memory_write: model date = 1900-01-07T00:00:00 memory =      -0.00 MB (highwater)        829.68 MB (usage)
764 Model Date: 1900-01-08T00:00:00 wall clock = 2025-08-22T13:43:04 avg dt =    52.37 s/day, dt =    43.08 s/day, rate =     5.49 ypd
765  memory_write: model date = 1900-01-08T00:00:00 memory =      -0.00 MB (highwater)        829.68 MB (usage)
766 Model Date: 1900-01-09T00:00:00 wall clock = 2025-08-22T13:43:46 avg dt =    51.10 s/day, dt =    42.20 s/day, rate =     5.61 ypd
767  memory_write: model date = 1900-01-09T00:00:00 memory =      -0.00 MB (highwater)        829.68 MB (usage)
768 Model Date: 1900-01-10T00:00:00 wall clock = 2025-08-22T13:44:28 avg dt =    50.08 s/day, dt =    41.95 s/day, rate =     5.64 ypd
769  memory_write: model date = 1900-01-10T00:00:00 memory =      -0.00 MB (highwater)        829.68 MB (usage)
770  -------->(med_phases_restart_write) mediating for: 1900  1 10 23 45  0   0
771 (med_io_wopen) creating file access-om3.cpl.r.1900-01-11-00000.nc
772 Model Date: 1900-01-11T00:00:00 wall clock = 2025-08-22T13:48:35 avg dt =    69.81 s/day, dt =   247.37 s/day, rate =     0.96 ypd
773  memory_write: model date = 1900-01-11T00:00:00 memory =      -0.00 MB (highwater)        829.68 MB (usage)
774   SUCCESSFUL TERMINATION OF CMEPS
775 : ===============  # simulated years / cmp-day =        3.394  ===============
```