### PR TITLE
Fixes/updates for tas5km regional

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,13 +8,13 @@
 # (you may need to add the corresponding PBS -l storage flag in sync_data.sh)
 # shortpath: /scratch/v45
 
-queue: normal
-ncpus: 240
+queue: normalsr
+ncpus: 208
 jobfs: 10GB
-mem: 900GB
+mem: 1000GB
 
-walltime: 24:00:00
-jobname: 1deg_jra55do_ryf_wombatlite
+walltime: 02:00:00
+jobname: tas5km_jra_iaf
 
 model: access-om3
 
@@ -40,15 +40,19 @@ runlog: false
 metadata: 
     enable: false
 
-    #userscripts:
-    setup: /usr/bin/bash /g/data/vk83/apps/om3-scripts/payu_config/setup.sh
-    archive: /usr/bin/bash /g/data/vk83/apps/om3-scripts/payu_config/archive.sh
+platform:
+    nodesize: 104
+    nodemem: 512
+
+# userscripts:
+#     setup: /usr/bin/bash /g/data/vk83/apps/om3-scripts/payu_config/setup.sh
+#     archive: /usr/bin/bash /g/data/vk83/apps/om3-scripts/payu_config/archive.sh
 
 modules:
     use:
         - /g/data/vk83/prerelease/modules
     load:
-        - access-om3/pr75-1
+        - access-om3/pr144-1
         - nco/5.0.5
 env:
 payu_minimum_version: 1.1.6

--- a/config.yaml
+++ b/config.yaml
@@ -33,7 +33,7 @@ input:
     - /g/data/ol01/ee8016/regional_wombat/ocean_mosaic.nc
     - /g/data/ol01/ee8016/regional_wombat/access-rom3-ESMFmesh.nc
     - /g/data/ol01/ee8016/regional_wombat/access-rom3-nomask-ESMFmesh.nc
-    - /g/data/ol01/ee8016/regional_wombat/dust_DS.nc
+    - /g/data/ol01/ee8016/regional_wombat/SFe_Hamiltonetal2020_monthly_clim.nc
     - /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/
 collate: false
 runlog: false

--- a/data_table
+++ b/data_table
@@ -1,8 +1,8 @@
 # MOM/FMS data table
 #
-# gridname | fieldname_code           | fieldname_file | file_name           | ongrid | factor
-# -------------------------------------------------------------------------------------------------
-"OCN"      , "co2_flux_pcair_atm"     , ""             , ""                  , "none" , 315.165e-06
-"OCN"      , "co2_nat_flux_pcair_atm" , ""             , ""                  , "none" , 284.262e-06
-"OCN"      , "o2_flux_pcair_atm"      , ""             , ""                  , "none" , 0.21
-"OCN"      , "dry_dep_fe_flux_ice_ocn", "dust"         , "./INPUT/dust_DS.nc", "none" , -1.0e-06
+# gridname | fieldname_code           | fieldname_file | file_name                                     | ongrid | factor
+# ----------------------------------------------------------------------------------------------------------------------
+"OCN"      , "co2_flux_pcair_atm"     , ""             , ""                                            , "none" , 315.165e-06
+"OCN"      , "co2_nat_flux_pcair_atm" , ""             , ""                                            , "none" , 284.262e-06
+"OCN"      , "o2_flux_pcair_atm"      , ""             , ""                                            , "none" , 0.21
+"OCN"      , "dry_dep_fe_flux_ice_ocn", "SFe"          , "./INPUT/SFe_Hamiltonetal2020_monthly_clim.nc", "none" , 1.0

--- a/docs/MOM_parameter_doc.all
+++ b/docs/MOM_parameter_doc.all
@@ -53,6 +53,46 @@ BULKMIXEDLAYER = False          !   [Boolean] default = False
                                 ! layers.  Layers 1 through NKML+NKBL have variable densities. There must be at
                                 ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true. BULKMIXEDLAYER can not be
                                 ! used with USE_REGRIDDING. The default is influenced by ENABLE_THERMODYNAMICS.
+USE_POROUS_BARRIER = False      !   [Boolean] default = False
+                                ! If true, use porous barrier to constrain the widths and face areas at the
+                                ! edges of the grid cells.
+BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
+                                ! If true, there are separate values for the basin depths at velocity points.
+                                ! Otherwise the effects of topography are entirely determined from thickness
+                                ! points.
+ENABLE_BUGS_BY_DEFAULT = True   !   [Boolean] default = True
+                                ! If true, the defaults for certain recently added bug-fix flags are set to
+                                ! recreate the bugs so that the code can be moved forward without changing
+                                ! answers for existing configurations.  The defaults for groups of bug-fix flags
+                                ! are periodcially changed to correct the bugs, at which point this parameter
+                                ! will no longer be used to set their default.  Setting this to false means that
+                                ! bugs are only used if they are actively selected, but it also means that
+                                ! answers may change when code is updated due to newly found bugs.
+DT = 300.0                      !   [s]
+                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
+                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
+                                ! or the coupling timestep in coupled mode.)
+DT_THERM = 1800.0               !   [s] default = 300.0
+                                ! The thermodynamic time step. Ideally DT_THERM should be an integer multiple of
+                                ! DT and of DT_TRACER_ADVECT and less than the forcing or coupling time-step.
+                                ! However, if THERMO_SPANS_COUPLING is true, DT_THERM can be an integer multiple
+                                ! of the coupling timestep. By default DT_THERM is set to DT.
+THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
+                                ! If true, the MOM will take thermodynamic timesteps that can be longer than the
+                                ! coupling timestep. The actual thermodynamic timestep that is used in this case
+                                ! is the largest integer multiple of the coupling timestep that is less than or
+                                ! equal to DT_THERM.
+DT_TRACER_ADVECT = 1800.0       !   [s] default = 1800.0
+                                ! The tracer advection time step. Ideally DT_TRACER_ADVECT should be an integer
+                                ! multiple of DT, less than DT_THERM, and less than the forcing or coupling
+                                ! time-step. However, if TRADV_SPANS_COUPLING is true, DT_TRACER_ADVECT can be
+                                ! longer than the coupling timestep. By default DT_TRACER_ADVECT is set to
+                                ! DT_THERM.
+TRADV_SPANS_COUPLING = False    !   [Boolean] default = False
+                                ! If true, the MOM will take tracer advection timesteps that can be longer than
+                                ! the coupling timestep. The actual tracer advection timestep that is used in
+                                ! this case is the largest integer multiple of the coupling timestep that is
+                                ! less than or equal to DT_TRACER_ADVECT.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
                                 ! If true, isopycnal surfaces are diffused with a Laplacian coefficient of KHTH.
 APPLY_INTERFACE_FILTER = False  !   [Boolean] default = False
@@ -61,27 +101,6 @@ APPLY_INTERFACE_FILTER = False  !   [Boolean] default = False
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
                                 ! If true, do thickness diffusion or interface height smoothing before dynamics.
                                 ! This is only used if THICKNESSDIFFUSE or APPLY_INTERFACE_FILTER is true.
-USE_POROUS_BARRIER = False      !   [Boolean] default = False
-                                ! If true, use porous barrier to constrain the widths and face areas at the
-                                ! edges of the grid cells.
-BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
-                                ! If true, there are separate values for the basin depths at velocity points.
-                                ! Otherwise the effects of topography are entirely determined from thickness
-                                ! points.
-DT = 300.0                      !   [s]
-                                ! The (baroclinic) dynamics time step.  The time-step that is actually used will
-                                ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
-                                ! or the coupling timestep in coupled mode.)
-DT_THERM = 1800.0               !   [s] default = 300.0
-                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
-                                ! an integer multiple of DT and less than the forcing or coupling time-step,
-                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
-                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
-THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
-                                ! If true, the MOM will take thermodynamic and tracer timesteps that can be
-                                ! longer than the coupling timestep. The actual thermodynamic timestep that is
-                                ! used in this case is the largest integer multiple of the coupling timestep
-                                ! that is less than or equal to DT_THERM.
 HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
                                 ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth over which to average
                                 ! to find surface properties like SST and SSS or density (but not surface
@@ -173,6 +192,8 @@ WRITE_GEOM = 1                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
                                 ! write the geometry and vertical grid files. Other values are invalid.
+GEOM_FILE = "ocean_geometry"    ! default = "ocean_geometry"
+                                ! The file into which to write the ocean geometry.
 USE_DBCLIENT = False            !   [Boolean] default = False
                                 ! If true, initialize a client to a remote database that can be used for online
                                 ! analysis and machine-learning inference.
@@ -328,27 +349,32 @@ OBC_RAMP_TIMESCALE = 1.0        !   [days] default = 1.0
                                 ! If RAMP_OBCS is true, this sets the ramping timescale.
 OBC_TIDE_N_CONSTITUENTS = 0     ! default = 0
                                 ! Number of tidal constituents being added to the open boundary.
+EXTERIOR_OBC_BUG = True         !   [Boolean] default = True
+                                ! If true, recover a bug in barotropic solver and other routines when boundary
+                                ! contitions interior to the domain are used.
+OBC_HOR_INDEXING_BUG = True     !   [Boolean] default = True
+                                ! If true, recover set of a horizontal indexing bugs in the OBC code.
 OBC_SEGMENT_001 = "J=N,I=N:0,FLATHER,ORLANSKI,NUDGED,ORLANSKI_TAN,NUDGED_TAN" !
                                 ! Documentation needs to be dynamic?????
-OBC_SEGMENT_001_VELOCITY_NUDGING_TIMESCALES = 0.3, 360.0 !   [days] default = 0.0
+OBC_SEGMENT_001_VELOCITY_NUDGING_TIMESCALES = 0.3, 360.0 !   [days]
                                 ! Timescales in days for nudging along a segment, for inflow, then outflow.
                                 ! Setting both to zero should behave like SIMPLE obcs for the baroclinic
                                 ! velocities.
 OBC_SEGMENT_002 = "J=0,I=0:N,FLATHER,ORLANSKI,NUDGED,ORLANSKI_TAN,NUDGED_TAN" !
                                 ! Documentation needs to be dynamic?????
-OBC_SEGMENT_002_VELOCITY_NUDGING_TIMESCALES = 0.3, 360.0 !   [days] default = 0.0
+OBC_SEGMENT_002_VELOCITY_NUDGING_TIMESCALES = 0.3, 360.0 !   [days]
                                 ! Timescales in days for nudging along a segment, for inflow, then outflow.
                                 ! Setting both to zero should behave like SIMPLE obcs for the baroclinic
                                 ! velocities.
 OBC_SEGMENT_003 = "I=N,J=0:N,FLATHER,ORLANSKI,NUDGED,ORLANSKI_TAN,NUDGED_TAN" !
                                 ! Documentation needs to be dynamic?????
-OBC_SEGMENT_003_VELOCITY_NUDGING_TIMESCALES = 0.3, 360.0 !   [days] default = 0.0
+OBC_SEGMENT_003_VELOCITY_NUDGING_TIMESCALES = 0.3, 360.0 !   [days]
                                 ! Timescales in days for nudging along a segment, for inflow, then outflow.
                                 ! Setting both to zero should behave like SIMPLE obcs for the baroclinic
                                 ! velocities.
 OBC_SEGMENT_004 = "I=0,J=N:0,FLATHER,ORLANSKI,NUDGED,ORLANSKI_TAN,NUDGED_TAN" !
                                 ! Documentation needs to be dynamic?????
-OBC_SEGMENT_004_VELOCITY_NUDGING_TIMESCALES = 0.3, 360.0 !   [days] default = 0.0
+OBC_SEGMENT_004_VELOCITY_NUDGING_TIMESCALES = 0.3, 360.0 !   [days]
                                 ! Timescales in days for nudging along a segment, for inflow, then outflow.
                                 ! Setting both to zero should behave like SIMPLE obcs for the baroclinic
                                 ! velocities.
@@ -386,7 +412,7 @@ REMAPPING_ANSWER_DATE = 99991231 ! default = 99991231
                                 ! Values below 20190101 result in the use of older, less accurate expressions
                                 ! that were in use at the end of 2018.  Higher values result in the use of more
                                 ! robust and accurate forms of mathematically equivalent expressions.
-OBC_REMAPPING_USE_OM4_SUBCELLS = True !   [Boolean] default = True
+OBC_REMAPPING_USE_OM4_SUBCELLS = False !   [Boolean] default = False
                                 ! If true, use the OM4 remapping-via-subcells algorithm for neutral diffusion.
                                 ! See REMAPPING_USE_OM4_SUBCELLS for more details. We recommend setting this
                                 ! option to false.
@@ -457,6 +483,13 @@ DTFREEZE_DS = -0.054            !   [degC ppt-1] default = -0.054
 DTFREEZE_DP = -7.75E-08         !   [degC Pa-1] default = 0.0
                                 ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
+TFREEZE_S_IS_PRACS = True       !   [Boolean] default = True
+                                ! When True, the model will check if the model internal salinity is practical
+                                ! salinity.  If the model uses absolute salinity, a conversion will be applied.
+TFREEZE_T_IS_POTT = True        !   [Boolean] default = True
+                                ! When True, the model will check if the model internal temperature is potential
+                                ! temperature.  If the model uses conservative temperature, a conversion will be
+                                ! applied.
 
 ! === module MOM_restart ===
 PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
@@ -472,12 +505,16 @@ RESTART_CHECKSUMS_REQUIRED = True !   [Boolean] default = True
                                 ! may want to avoid this comparison if for example the restarts are made from a
                                 ! run with a different mask_table than the current run, in which case the
                                 ! checksums will not match and cause crash.
-STREAMING_FILTER_M2 = False     !   [Boolean] default = False
-                                ! If true, turn on streaming band-pass filter for detecting instantaneous tidal
-                                ! signals.
-STREAMING_FILTER_K1 = False     !   [Boolean] default = False
-                                ! If true, turn on streaming band-pass filter for detecting instantaneous tidal
-                                ! signals.
+RESTART_SYMMETRIC_CHECKSUMS = False !   [Boolean] default = False
+                                ! If true, do the restart checksums on all the edge points for a non-reentrant
+                                ! grid.  This requires that SYMMETRIC_MEMORY_ is defined at compile time.
+RESTART_UNSIGNED_ZEROS = False  !   [Boolean] default = False
+                                ! If true, convert any negative zeros that would be written to the restart file
+                                ! into ordinary unsigned zeros.  This does not change answers, but it can be
+                                ! helpful in comparing restart files after grid rotation, for example.
+USE_FILTER = False              !   [Boolean] default = False
+                                ! If true, use streaming band-pass filters to detect the instantaneous tidal
+                                ! signals in the simulation.
 
 ! === module MOM_tracer_flow_control ===
 USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
@@ -490,6 +527,8 @@ USE_RGC_TRACER = False          !   [Boolean] default = False
                                 ! If true, use the RGC_tracer tracer package.
 USE_IDEAL_AGE_TRACER = False    !   [Boolean] default = False
                                 ! If true, use the ideal_age_example tracer package.
+USE_MARBL_TRACERS = False       !   [Boolean] default = False
+                                ! If true, use the MARBL tracer package.
 USE_REGIONAL_DYES = False       !   [Boolean] default = False
                                 ! If true, use the regional_dyes tracer package.
 USE_OIL_TRACER = False          !   [Boolean] default = False
@@ -536,6 +575,17 @@ USE_DYED_CHANNEL_OBC = False    !   [Boolean] default = False
                                 ! If true, use the dyed channel open boundary.
 
 ! === module segment_tracer_registry_init ===
+
+! === module MOM_hor_index ===
+! Sets the horizontal array index types.
+
+! === module MOM_fixed_initialization ===
+
+! === module MOM_grid_init ===
+
+! === module MOM_open_boundary ===
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 
 ! === module MOM_coord_initialization ===
 COORD_CONFIG = "none"           ! default = "none"
@@ -660,6 +710,10 @@ REMAP_VEL_MASK_BBL_THICK = -0.001 !   [m] default = -0.001
                                 ! A thickness of a bottom boundary layer below which velocities in thin layers
                                 ! are zeroed out after remapping, following practice with Hybgen remapping, or a
                                 ! negative value to avoid such filtering altogether.
+REMAP_VEL_CONSERVE_KE = False   !   [Boolean] default = False
+                                ! If true, a correction is applied to the baroclinic component of velocity after
+                                ! remapping so that total KE is conserved. KE may not be conserved when
+                                ! (CS%BBL_h_vel_mask > 0.0) .and. (CS%h_vel_mask > 0.0)
 
 ! === module MOM_state_initialization ===
 FATAL_INCONSISTENT_RESTART_TIME = False !   [Boolean] default = False
@@ -702,7 +756,7 @@ TEMP_SALT_INIT_VERTICAL_REMAP_ONLY = True !   [Boolean] default = False
                                 ! If true, initial conditions are on the model horizontal grid. Extrapolation
                                 ! over missing ocean values is done using an ICE-9 procedure with vertical ALE
                                 ! remapping .
-Z_INIT_REMAPPING_USE_OM4_SUBCELLS = False !   [Boolean] default = True
+Z_INIT_REMAPPING_USE_OM4_SUBCELLS = False !   [Boolean] default = False
                                 ! If true, use the OM4 remapping-via-subcells algorithm for initialization. See
                                 ! REMAPPING_USE_OM4_SUBCELLS for more details. We recommend setting this option
                                 ! to false.
@@ -762,6 +816,10 @@ ODA_INCUPD = False              !   [Boolean] default = False
 SPONGE = False                  !   [Boolean] default = False
                                 ! If true, sponges may be applied anywhere in the domain. The exact location and
                                 ! properties of those sponges are specified via SPONGE_CONFIG.
+OBC_RESERVOIR_INIT_BUG = True   !   [Boolean] default = True
+                                ! If true, set the OBC tracer reservoirs at the startup of a new run from the
+                                ! interior tracer concentrations regardless of properties that may be explicitly
+                                ! specified for the reservoir concentrations.
 OBC_SEGMENT_001_DATA = "U=file:obgc_obc.nc(u),V=file:obgc_obc.nc(v),SSH=file:obgc_obc.nc(eta),TEMP=file:obgc_obc.nc(temp),SALT=file:obgc_obc.nc(salt)" !
                                 ! OBC segment docs
 OBC_SEGMENT_002_DATA = "U=file:obgc_obc.nc(u),V=file:obgc_obc.nc(v),SSH=file:obgc_obc.nc(eta),TEMP=file:obgc_obc.nc(temp),SALT=file:obgc_obc.nc(salt)" !
@@ -785,7 +843,7 @@ OBC_USER_CONFIG = "none"        ! default = "none"
 NUM_DIAG_COORDS = 1             ! default = 1
                                 ! The number of diagnostic vertical coordinates to use. For each coordinate, an
                                 ! entry in DIAG_COORDS must be provided.
-DIAG_REMAPPING_USE_OM4_SUBCELLS = False !   [Boolean] default = True
+DIAG_REMAPPING_USE_OM4_SUBCELLS = False !   [Boolean] default = False
                                 ! If true, use the OM4 remapping-via-subcells algorithm for diagnostics. See
                                 ! REMAPPING_USE_OM4_SUBCELLS for details. We recommend setting this option to
                                 ! false.
@@ -884,6 +942,8 @@ MEKE_K4 = -1.0                  !   [m4 s-1] default = -1.0
                                 ! bi-harmonic diffusion to MEKE.
 MEKE_DTSCALE = 1.0              !   [nondim] default = 1.0
                                 ! A scaling factor to accelerate the time evolution of MEKE.
+MEKE_POSITIVE = False           !   [Boolean] default = False
+                                ! If true, it guarantees that MEKE will always be >= 0.
 MEKE_KHCOEFF = 1.0              !   [nondim] default = 1.0
                                 ! A scaling factor in the expression for eddy diffusivity which is otherwise
                                 ! proportional to the MEKE velocity- scale times an eddy mixing-length. This
@@ -1010,9 +1070,6 @@ BACKSCAT_EBT_POWER = 0.0        !   [nondim] default = 0.0
 BS_USE_SQG_STRUCT = False       !   [Boolean] default = False
                                 ! If true, the SQG vertical structure is used for backscatter on the condition
                                 ! that BS_EBT_power=0
-SQG_EXPO = 1.0                  !   [nondim] default = 1.0
-                                ! Nondimensional exponent coeffecient of the SQG mode that is used for the
-                                ! vertical struture of diffusivities.
 KHTH_USE_EBT_STRUCT = True      !   [Boolean] default = False
                                 ! If true, uses the equivalent barotropic structure as the vertical structure of
                                 ! thickness diffusivity.
@@ -1047,6 +1104,10 @@ VERY_SMALL_FREQUENCY = 1.0E-17  !   [s-1] default = 1.0E-17
 USE_STANLEY_ISO = False         !   [Boolean] default = False
                                 ! If true, turn on Stanley SGS T variance parameterization in isopycnal slope
                                 ! code.
+MIXING_COEFS_OBC_BUG = True     !   [Boolean] default = True
+                                ! If false, use only interior data for thickness weighting in lateral mixing
+                                ! coefficient calculations and to calculate stratification and other fields at
+                                ! open boundary condition faces.
 RESOLN_N2_FILTER_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is monotonized to avoid stratification artifacts from
                                 ! altering the equivalent barotropic mode structure.  This monotonzization is
@@ -1099,7 +1160,7 @@ INTERNAL_WAVE_SPEED_MIN = 0.0   !   [m s-1] default = 0.0
 INTERNAL_WAVE_SPEED_BETTER_EST = True !   [Boolean] default = True
                                 ! If true, use a more robust estimate of the first mode wave speed as the
                                 ! starting point for iterations.
-EBT_REMAPPING_USE_OM4_SUBCELLS = False !   [Boolean] default = True
+EBT_REMAPPING_USE_OM4_SUBCELLS = False !   [Boolean] default = False
                                 ! If true, use the OM4 remapping-via-subcells algorithm for calculating EBT
                                 ! structure. See REMAPPING_USE_OM4_SUBCELLS for details. We recommend setting
                                 ! this option to false.
@@ -1126,8 +1187,6 @@ CHANNEL_DRAG = True             !   [Boolean] default = False
 LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
                                 ! cdrag*DRAG_BG_VEL*u.
-PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
-                                ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
                                 ! If true, use a bulk Richardson number criterion to determine the mixed layer
                                 ! thickness for viscosity.
@@ -1268,6 +1327,8 @@ BEGW = 0.0                      !   [nondim] default = 0.0
                                 ! which the treatment of gravity waves is forward-backward (0) or simulated
                                 ! backward Euler (1).  0 is almost always used. If SPLIT is false and USE_RK2 is
                                 ! true, BEGW can be between 0 and 0.5 to damp gravity waves.
+SET_DTBT_USE_BT_CONT = False    !   [Boolean] default = False
+                                ! If true, use BT_CONT to calculate DTBT if possible.
 SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
                                 ! If true, provide the bottom stress calculated by the vertical viscosity to the
                                 ! barotropic solver.
@@ -1278,7 +1339,8 @@ STORE_CORIOLIS_ACCEL = True     !   [Boolean] default = True
                                 ! If true, calculate the Coriolis accelerations at the end of each timestep for
                                 ! use in the predictor step of the next split RK2 timestep.
 FPMIX = False                   !   [Boolean] default = False
-                                ! If true, apply profiles of momentum flux magnitude and  direction
+                                ! If true, add non-local momentum flux increments and diffuse down the Eulerian
+                                ! gradient.
 VISC_REM_BUG = False            !   [Boolean] default = True
                                 ! If true, visc_rem_[uv] in split mode is incorrectly calculated or accounted
                                 ! for in two places. This parameter controls the defaults of two individual
@@ -1375,6 +1437,11 @@ RHO_PGF_REF = 1035.0            !   [kg m-3] default = 1035.0
                                 ! The reference density that is subtracted off when calculating pressure
                                 ! gradient forces.  Its inverse is subtracted off of specific volumes when in
                                 ! non-Boussinesq mode.  The default is RHO_0.
+RHO_PGF_REF_BUG = True          !   [Boolean] default = True
+                                ! If true, recover a bug that RHO_0 (the mean seawater density in Boussinesq
+                                ! mode) and RHO_PGF_REF (the subtracted reference density in finite volume
+                                ! pressure gradient forces) are incorrectly interchanged in several instances in
+                                ! Boussinesq mode.
 SSH_IN_EOS_PRESSURE_FOR_PGF = False !   [Boolean] default = False
                                 ! If true, include contributions from the sea surface height in the height-based
                                 ! pressure used in the equation of state calculations for the Boussinesq
@@ -1387,11 +1454,17 @@ MASS_WEIGHT_IN_PRESSURE_GRADIENT_TOP = False !   [Boolean] default = False
                                 ! If true and MASS_WEIGHT_IN_PRESSURE_GRADIENT is true, use mass weighting when
                                 ! interpolating T/S for integrals near the top of the water column in FV
                                 ! pressure gradient calculations.
+MASS_WEIGHT_IN_PGF_VANISHED_ONLY = False !   [Boolean] default = False
+                                ! If true, use mass weighting when interpolating T/S for integrals only if one
+                                ! side is vanished according to RESET_INTXPA_H_NONVANISHED.
 CORRECTION_INTXPA = False       !   [Boolean] default = False
                                 ! If true, use a correction for surface pressure curvature in intx_pa.
 RESET_INTXPA_INTEGRAL = False   !   [Boolean] default = False
                                 ! If true, reset INTXPA to match pressures at first nonvanished cell. Includes
                                 ! pressure correction.
+RESET_INTXPA_INTEGRAL_FLATTEST = False !   [Boolean] default = False
+                                ! If true, use flattest interface as reference interface where there is no
+                                ! better choice for RESET_INTXPA_INTEGRAL. Otherwise, use surface interface.
 USE_INACCURATE_PGF_RHO_ANOM = False !   [Boolean] default = False
                                 ! If true, use a form of the PGF that uses the reference density in an
                                 ! inaccurate way. This is not recommended.
@@ -1664,6 +1737,9 @@ BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities, using rates set by
                                 ! lin_drag_u & _v divided by the depth of the ocean.  This was introduced to
                                 ! facilitate tide modeling.
+BT_LINEAR_FREQ_DRAG = False     !   [Boolean] default = False
+                                ! If true, apply frequency-dependent drag to the tidal velocities. The streaming
+                                ! band-pass filter must be turned on.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed CFL_TRUNCATE.  This should
                                 ! only be used as a desperate debugging measure.
@@ -1726,6 +1802,8 @@ MLE_FRONT_LENGTH = 1000.0       !   [m] default = 0.0
                                 ! buoyancy gradients that is otherwise represented by the parameter
                                 ! FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is non-zero, it is recommended
                                 ! to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
+MLE_FRONT_LENGTH_FROM_FILE = False !   [Boolean] default = False
+                                ! If true, the MLE front-length scale is read from a file.
 MLE_USE_PBL_MLD = False         !   [Boolean] default = False
                                 ! If true, the MLE parameterization will use the mixed-layer depth provided by
                                 ! the active PBL parameterization. If false, MLE will estimate a MLD based on a
@@ -1765,7 +1843,7 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-INTWAVE_REMAPPING_USE_OM4_SUBCELLS = False !   [Boolean] default = True
+INTWAVE_REMAPPING_USE_OM4_SUBCELLS = False !   [Boolean] default = False
                                 ! If true, use the OM4 remapping-via-subcells algorithm for calculating EBT
                                 ! structure. See REMAPPING_USE_OM4_SUBCELLS for details. We recommend setting
                                 ! this option to false.
@@ -1818,7 +1896,7 @@ EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
                                 ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
                                 ! sea-ice formation) in one time-step. The unused mass loss is passed down
                                 ! through the column.
-MLD_EN_VALS = 3*0.0             !   [J/m2] default = 0.0
+MLD_EN_VALS = 25.0, 2500.0, 2.5E+05 !   [J/m2] default = 25.0, 2500.0, 2.5E+05
                                 ! The energy values used to compute MLDs.  If not set (or all set to 0.), the
                                 ! default will overwrite to 25., 2500., 250000.
 HREF_FOR_MLD = 0.0              !   [m] default = 0.0
@@ -1862,6 +1940,8 @@ INTERP_TYPE = "quadratic"       ! default = "quadratic"
 INTERP_TYPE2 = "LMD94"          ! default = "LMD94"
                                 ! Type of interpolation to compute diff and visc at OBL_depth.
                                 ! Allowed types are: linear, quadratic, cubic or LMD94.
+STOKES_MOST = False             !   [Boolean] default = False
+                                ! If True, use Stokes Similarity package.
 COMPUTE_EKMAN = False           !   [Boolean] default = False
                                 ! If True, limit OBL depth to be no deeper than Ekman depth.
 COMPUTE_MONIN_OBUKHOV = False   !   [Boolean] default = False
@@ -1924,6 +2004,8 @@ STOKES_MIXING = False           !   [Boolean] default = False
                                 ! Flag for Langmuir turbulence enhancement of turbulentmixing coefficient.
 USE_KPP_LT_VT2 = False          !   [Boolean] default = False
                                 ! Flag for Langmuir turbulence enhancement of Vt2in Bulk Richardson Number.
+KPP_CVt2 = 1.6                  !   [nondim] default = 1.6
+                                ! Parameter for Stokes MOST convection entrainment
 ANSWER_DATE = 20240101          ! default = 20240101
                                 ! The vintage of the order of arithmetic in the CVMix KPP calculations.  Values
                                 ! below 20240501 recover the answers from early in 2024, while higher values use
@@ -1957,6 +2039,8 @@ SET_DIFF_ANSWER_DATE = 99991231 ! default = 99991231
                                 ! The vintage of the order of arithmetic and expressions in the set diffusivity
                                 ! calculations.  Values below 20190101 recover the answers from the end of 2018,
                                 ! while higher values use updated and more robust forms of the same expressions.
+                                ! Values above 20250301 also use less confusing expressions to set the
+                                ! bottom-drag generated diffusivity when USE_LOTW_BBL_DIFFUSIVITY is false.
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
@@ -2049,6 +2133,9 @@ DOUBLE_DIFFUSION = False        !   [Boolean] default = False
 USE_JACKSON_PARAM = False       !   [Boolean] default = False
                                 ! If true, use the Jackson-Hallberg-Legg (JPO 2008) shear mixing
                                 ! parameterization.
+VERTEX_SHEAR_THICKNESS_MEAN = False !   [Boolean] default = False
+                                ! If true, apply thickness weighting to horizontal averagings of diffusivity to
+                                ! tracer points in the kappa shear solver.
 KD_SEED_KAPPA_SHEAR = 1.0       !   [m2 s-1] default = 1.0
                                 ! A moderately large seed value of diapycnal diffusivity that is used as a
                                 ! starting turbulent diffusivity in the iterations to find an energetically
@@ -2185,8 +2272,13 @@ KHTR = 0.0                      !   [m2 s-1] default = 0.0
                                 ! The background along-isopycnal tracer diffusivity.
 KHTR_MIN = 50.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum along-isopycnal tracer diffusivity.
+FULL_DEPTH_KHTR_MIN = False     !   [Boolean] default = False
+                                ! If true, KHTR_MIN is enforced throughout the whole water column. Otherwise,
+                                ! KHTR_MIN is only enforced at the surface. This parameter is only available
+                                ! when KHTR_USE_EBT_STRUCT=True and KHTR_MIN>0.
 KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
-                                ! The maximum along-isopycnal tracer diffusivity.
+                                ! The maximum along-isopycnal tracer diffusivity. Set to a positive value to
+                                ! activate.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over grid-spacing in passivity,
                                 ! where passivity is the ratio between along isopycnal mixing of tracers to
@@ -2264,12 +2356,10 @@ HBD_REMAPPING_SCHEME = "PLM"    ! default = "PLM"
                                 ! WENO_HYBGEN (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
-HBD_REMAPPING_USE_OM4_SUBCELLS = False !   [Boolean] default = True
+HBD_REMAPPING_USE_OM4_SUBCELLS = False !   [Boolean] default = False
                                 ! If true, use the OM4 remapping-via-subcells algorithm for horizontal boundary
                                 ! diffusion. See REMAPPING_USE_OM4_SUBCELLS for details. We recommend setting
                                 ! this option to false.
-HBD_DEBUG = False               !   [Boolean] default = False
-                                ! If true, write out verbose debugging data in the HBD module.
 OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
                                 ! If an obsolete diagnostic variable appears in the diag_table, cause a FATAL
                                 ! error rather than issue a WARNING.
@@ -2294,6 +2384,8 @@ ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
                                 ! The file to use to write the energies and globally summed diagnostics.
 DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
                                 ! If true, use dates (not times) in messages to stdout
+ISO_DATE_STAMPED_STDOUT = False !   [Boolean] default = False
+                                ! If true, use ISO formatted dates in messages to stdout
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit in seconds a number of input fields
 READ_DEPTH_LIST = False         !   [Boolean] default = False
@@ -2311,9 +2403,12 @@ ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
 
 ! === module ocean_stochastics_init ===
 DO_SPPT = False                 !   [Boolean] default = False
-                                ! If true, then stochastically perturb the thermodynamic tendemcies of T,S, amd
+                                ! If true, then stochastically perturb the thermodynamic tendencies of T,S, amd
                                 ! h.  Amplitude and correlations are controlled by the nam_stoch namelist in the
                                 ! UFS model only.
+DO_SKEB = False                 !   [Boolean] default = False
+                                ! If true, then stochastically perturb the currents using the stochastic kinetic
+                                ! energy backscatter scheme.
 PERT_EPBL = False               !   [Boolean] default = False
                                 ! If true, then stochastically perturb the kinetic energy production and
                                 ! dissipation terms.  Amplitude and correlations are controlled by the nam_stoch
@@ -2409,6 +2504,9 @@ USE_RIGID_SEA_ICE = False       !   [Boolean] default = False
                                 ! resist vertical motion.
 ALLOW_ICEBERG_FLUX_DIAGNOSTICS = False !   [Boolean] default = False
                                 ! If true, makes available diagnostics of fluxes from icebergs as seen by MOM6.
+ALLOW_GLC_RUNOFF_DIAGNOSTICS = False !   [Boolean] default = False
+                                ! If true, makes available diagnostics of separate glacier runoff fluxesas seen
+                                ! by MOM6.
 ALLOW_FLUX_ADJUSTMENTS = False  !   [Boolean] default = False
                                 ! If true, allows flux adjustments to specified via the data_table using the
                                 ! component name 'OCN'.

--- a/docs/MOM_parameter_doc.debugging
+++ b/docs/MOM_parameter_doc.debugging
@@ -36,6 +36,8 @@ DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
                                 ! If true, calculate all diagnostics that are useful for debugging truncations.
+DEBUG_OBCS = False              !   [Boolean] default = False
+                                ! If true, write out verbose debugging data about OBCs.
 ROTATE_INDEX = False            !   [Boolean] default = False
                                 ! Enable rotation of the horizontal indices.
 DEBUG_CHKSUMS = False           !   [Boolean] default = False
@@ -43,6 +45,9 @@ DEBUG_CHKSUMS = False           !   [Boolean] default = False
 DEBUG_REDUNDANT = False         !   [Boolean] default = False
                                 ! If true, debug redundant data points during calls to the various vec_chksum
                                 ! routines.
+OBC_DEBUGGING_TESTS = False     !   [Boolean] default = False
+                                ! If true, do additional calls resetting certain values to help verify the
+                                ! correctness of the open boundary condition code.
 
 ! === module MOM_verticalGrid ===
 ! Parameters providing information about the vertical grid.
@@ -77,6 +82,8 @@ DEBUG_BT = False                !   [Boolean] default = False
 ! The following parameters are used for diabatic processes.
 DEBUG_CONSERVATION = False      !   [Boolean] default = False
                                 ! If true, monitor conservation and extrema.
+HBD_DEBUG = False               !   [Boolean] default = False
+                                ! If true, write out verbose debugging data in the HBD module.
 WRITE_TRACER_MIN_MAX = False    !   [Boolean] default = False
                                 ! If true, write the maximum and minimum values of temperature, salinity and
                                 ! some tracer concentrations to stdout when the energy files are written.

--- a/docs/MOM_parameter_doc.layout
+++ b/docs/MOM_parameter_doc.layout
@@ -38,13 +38,13 @@ MASKTABLE = "MOM_auto_mask_table" ! default = "MOM_mask_table"
                                 !  4,6
                                 !  1,2
                                 !  3,6
-NIPROC = 11                     !
+NIPROC = 10                     !
                                 ! The number of processors in the x-direction. With STATIC_MEMORY_ this is set
                                 ! in MOM_memory.h at compile time.
-NJPROC = 23                     !
+NJPROC = 20                     !
                                 ! The number of processors in the y-direction. With STATIC_MEMORY_ this is set
                                 ! in MOM_memory.h at compile time.
-LAYOUT = 11, 23                 !
+LAYOUT = 10, 20                 !
                                 ! The processor layout that was actually used.
 AUTO_IO_LAYOUT_FAC = 0          ! default = 0
                                 ! When AUTO_MASKTABLE is enabled, io layout is calculated by performing integer
@@ -67,6 +67,10 @@ BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
                                 ! efficiency.
 BTHALO = 0                      ! default = 0
                                 ! The minimum halo size for the barotropic solver.
+BT_WIDE_HALO_MIN_STENCIL = 0    ! default = 0
+                                ! The minimum stencil width to use with the wide halo iterations. A nonzero
+                                ! value may be useful for debugging purposes, but at the cost of reducing the
+                                ! efficiency gain from BT_USE_WIDE_HALOS.
 !BT x-halo = 4                  !
                                 ! The barotropic x-halo size that is actually used.
 !BT y-halo = 4                  !

--- a/docs/MOM_parameter_doc.short
+++ b/docs/MOM_parameter_doc.short
@@ -4,20 +4,20 @@
 USE_REGRIDDING = True           !   [Boolean] default = False
                                 ! If True, use the ALE algorithm (regridding/remapping). If False, use the
                                 ! layered isopycnal algorithm.
-THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, isopycnal surfaces are diffused with a Laplacian coefficient of KHTH.
-THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion or interface height smoothing before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE or APPLY_INTERFACE_FILTER is true.
 DT = 300.0                      !   [s]
                                 ! The (baroclinic) dynamics time step.  The time-step that is actually used will
                                 ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
                                 ! or the coupling timestep in coupled mode.)
 DT_THERM = 1800.0               !   [s] default = 300.0
-                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
-                                ! an integer multiple of DT and less than the forcing or coupling time-step,
-                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
-                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
+                                ! The thermodynamic time step. Ideally DT_THERM should be an integer multiple of
+                                ! DT and of DT_TRACER_ADVECT and less than the forcing or coupling time-step.
+                                ! However, if THERMO_SPANS_COUPLING is true, DT_THERM can be an integer multiple
+                                ! of the coupling timestep. By default DT_THERM is set to DT.
+THICKNESSDIFFUSE = True         !   [Boolean] default = False
+                                ! If true, isopycnal surfaces are diffused with a Laplacian coefficient of KHTH.
+THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
+                                ! If true, do thickness diffusion or interface height smoothing before dynamics.
+                                ! This is only used if THICKNESSDIFFUSE or APPLY_INTERFACE_FILTER is true.
 HFREEZE = 10.0                  !   [m] default = -1.0
                                 ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
@@ -130,25 +130,25 @@ OBC_ZERO_BIHARMONIC = True      !   [Boolean] default = False
                                 ! viscosity term.
 OBC_SEGMENT_001 = "J=N,I=N:0,FLATHER,ORLANSKI,NUDGED,ORLANSKI_TAN,NUDGED_TAN" !
                                 ! Documentation needs to be dynamic?????
-OBC_SEGMENT_001_VELOCITY_NUDGING_TIMESCALES = 0.3, 360.0 !   [days] default = 0.0
+OBC_SEGMENT_001_VELOCITY_NUDGING_TIMESCALES = 0.3, 360.0 !   [days]
                                 ! Timescales in days for nudging along a segment, for inflow, then outflow.
                                 ! Setting both to zero should behave like SIMPLE obcs for the baroclinic
                                 ! velocities.
 OBC_SEGMENT_002 = "J=0,I=0:N,FLATHER,ORLANSKI,NUDGED,ORLANSKI_TAN,NUDGED_TAN" !
                                 ! Documentation needs to be dynamic?????
-OBC_SEGMENT_002_VELOCITY_NUDGING_TIMESCALES = 0.3, 360.0 !   [days] default = 0.0
+OBC_SEGMENT_002_VELOCITY_NUDGING_TIMESCALES = 0.3, 360.0 !   [days]
                                 ! Timescales in days for nudging along a segment, for inflow, then outflow.
                                 ! Setting both to zero should behave like SIMPLE obcs for the baroclinic
                                 ! velocities.
 OBC_SEGMENT_003 = "I=N,J=0:N,FLATHER,ORLANSKI,NUDGED,ORLANSKI_TAN,NUDGED_TAN" !
                                 ! Documentation needs to be dynamic?????
-OBC_SEGMENT_003_VELOCITY_NUDGING_TIMESCALES = 0.3, 360.0 !   [days] default = 0.0
+OBC_SEGMENT_003_VELOCITY_NUDGING_TIMESCALES = 0.3, 360.0 !   [days]
                                 ! Timescales in days for nudging along a segment, for inflow, then outflow.
                                 ! Setting both to zero should behave like SIMPLE obcs for the baroclinic
                                 ! velocities.
 OBC_SEGMENT_004 = "I=0,J=N:0,FLATHER,ORLANSKI,NUDGED,ORLANSKI_TAN,NUDGED_TAN" !
                                 ! Documentation needs to be dynamic?????
-OBC_SEGMENT_004_VELOCITY_NUDGING_TIMESCALES = 0.3, 360.0 !   [days] default = 0.0
+OBC_SEGMENT_004_VELOCITY_NUDGING_TIMESCALES = 0.3, 360.0 !   [days]
                                 ! Timescales in days for nudging along a segment, for inflow, then outflow.
                                 ! Setting both to zero should behave like SIMPLE obcs for the baroclinic
                                 ! velocities.
@@ -186,6 +186,14 @@ USE_generic_tracer = True       !   [Boolean] default = False
 ! === module MOM_boundary_update ===
 
 ! === module segment_tracer_registry_init ===
+
+! === module MOM_fixed_initialization ===
+
+! === module MOM_grid_init ===
+
+! === module MOM_open_boundary ===
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
+! if any.
 
 ! === module MOM_coord_initialization ===
 REGRIDDING_COORDINATE_MODE = "ZSTAR" ! default = "LAYER"
@@ -254,10 +262,6 @@ TEMP_SALT_INIT_VERTICAL_REMAP_ONLY = True !   [Boolean] default = False
                                 ! If true, initial conditions are on the model horizontal grid. Extrapolation
                                 ! over missing ocean values is done using an ICE-9 procedure with vertical ALE
                                 ! remapping .
-Z_INIT_REMAPPING_USE_OM4_SUBCELLS = False !   [Boolean] default = True
-                                ! If true, use the OM4 remapping-via-subcells algorithm for initialization. See
-                                ! REMAPPING_USE_OM4_SUBCELLS for more details. We recommend setting this option
-                                ! to false.
 DEPRESS_INITIAL_SURFACE = True  !   [Boolean] default = False
                                 ! If true,  depress the initial surface to avoid huge tsunamis when a large
                                 ! surface pressure is applied.
@@ -288,10 +292,6 @@ OBC_SEGMENT_004_DATA = "U=file:obgc_obc.nc(u),V=file:obgc_obc.nc(v),SSH=file:obg
                                 ! OBC segment docs
 
 ! === module MOM_diag_mediator ===
-DIAG_REMAPPING_USE_OM4_SUBCELLS = False !   [Boolean] default = True
-                                ! If true, use the OM4 remapping-via-subcells algorithm for diagnostics. See
-                                ! REMAPPING_USE_OM4_SUBCELLS for details. We recommend setting this option to
-                                ! false.
 DIAG_COORD_DEF_Z = "FILE:vcoord.nc,interfaces=zi" ! default = "WOA09"
                                 ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
@@ -388,10 +388,6 @@ USE_STORED_SLOPES = True        !   [Boolean] default = False
 KH_RES_SCALE_COEF = 0.4         !   [nondim] default = 1.0
                                 ! A coefficient that determines how KhTh is scaled away if RESOLN_SCALED_... is
                                 ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
-EBT_REMAPPING_USE_OM4_SUBCELLS = False !   [Boolean] default = True
-                                ! If true, use the OM4 remapping-via-subcells algorithm for calculating EBT
-                                ! structure. See REMAPPING_USE_OM4_SUBCELLS for details. We recommend setting
-                                ! this option to false.
 
 ! === module MOM_set_visc ===
 CHANNEL_DRAG = True             !   [Boolean] default = False
@@ -540,10 +536,6 @@ MLE_MLD_DECAY_TIME = 3.456E+05  !   [s] default = 0.0
                                 ! MLD.
 
 ! === module MOM_diagnostics ===
-INTWAVE_REMAPPING_USE_OM4_SUBCELLS = False !   [Boolean] default = True
-                                ! If true, use the OM4 remapping-via-subcells algorithm for calculating EBT
-                                ! structure. See REMAPPING_USE_OM4_SUBCELLS for details. We recommend setting
-                                ! this option to false.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
@@ -666,10 +658,6 @@ USE_HORIZONTAL_BOUNDARY_DIFFUSION = True !   [Boolean] default = False
 HBD_LINEAR_TRANSITION = True    !   [Boolean] default = False
                                 ! If True, apply a linear transition at the base/top of the boundary.
                                 ! The flux will be fully applied at k=k_min and zero at k=k_max.
-HBD_REMAPPING_USE_OM4_SUBCELLS = False !   [Boolean] default = True
-                                ! If true, use the OM4 remapping-via-subcells algorithm for horizontal boundary
-                                ! diffusion. See REMAPPING_USE_OM4_SUBCELLS for details. We recommend setting
-                                ! this option to false.
 
 ! === module MOM_sum_output ===
 

--- a/docs/available_diags.000000
+++ b/docs/available_diags.000000
@@ -1,5 +1,6 @@
-"volcello"  [Unused]
+"volcello"  [Used]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Ocean grid-cell volume
     ! units: m3
     ! standard_name: ocean_volume
@@ -7,124 +8,153 @@
     ! variants: {volcello,volcello_xyave}
 "geolat"  [Used]
     ! modules: ocean_model
+    ! dimensions: xh, yh
     ! long_name: Latitude of tracer (T) points
     ! units: degrees_north
 "geolon"  [Used]
     ! modules: ocean_model
+    ! dimensions: xh, yh
     ! long_name: Longitude of tracer (T) points
     ! units: degrees_east
 "geolat_c"  [Used]
     ! modules: ocean_model
+    ! dimensions: xq, yq
     ! long_name: Latitude of corner (Bu) points
     ! units: degrees_north
 "geolon_c"  [Used]
     ! modules: ocean_model
+    ! dimensions: xq, yq
     ! long_name: Longitude of corner (Bu) points
     ! units: degrees_east
 "geolat_v"  [Used]
     ! modules: ocean_model
+    ! dimensions: xh, yq
     ! long_name: Latitude of meridional velocity (Cv) points
     ! units: degrees_north
 "geolon_v"  [Used]
     ! modules: ocean_model
+    ! dimensions: xh, yq
     ! long_name: Longitude of meridional velocity (Cv) points
     ! units: degrees_east
 "geolat_u"  [Used]
     ! modules: ocean_model
+    ! dimensions: xq, yh
     ! long_name: Latitude of zonal velocity (Cu) points
     ! units: degrees_north
 "geolon_u"  [Used]
     ! modules: ocean_model
+    ! dimensions: xq, yh
     ! long_name: Longitude of zonal velocity (Cu) points
     ! units: degrees_east
 "area_t"  [Unused]
     ! modules: ocean_model
+    ! dimensions: xh, yh
     ! long_name: Surface area of tracer (T) cells
     ! units: m2
     ! variants: {area_t,areacello}
 "area_u"  [Unused]
     ! modules: ocean_model
+    ! dimensions: xq, yh
     ! long_name: Surface area of x-direction flow (U) cells
     ! units: m2
     ! variants: {area_u,areacello_cu}
 "area_v"  [Unused]
     ! modules: ocean_model
+    ! dimensions: xh, yq
     ! long_name: Surface area of y-direction flow (V) cells
     ! units: m2
     ! variants: {area_v,areacello_cv}
 "area_q"  [Unused]
     ! modules: ocean_model
+    ! dimensions: xq, yq
     ! long_name: Surface area of B-grid flow (Q) cells
     ! units: m2
     ! variants: {area_q,areacello_bu}
 "depth_ocean"  [Unused]
     ! modules: ocean_model
+    ! dimensions: xh, yh
     ! long_name: Depth of the ocean at tracer points
     ! units: m
     ! standard_name: sea_floor_depth_below_geoid
     ! variants: {depth_ocean,deptho}
 "wet"  [Used]
     ! modules: ocean_model
+    ! dimensions: xh, yh
     ! long_name: 0 if land, 1 if ocean at tracer points
     ! units: none
 "wet_c"  [Used]
     ! modules: ocean_model
+    ! dimensions: xq, yq
     ! long_name: 0 if land, 1 if ocean at corner (Bu) points
     ! units: none
 "wet_u"  [Used]
     ! modules: ocean_model
+    ! dimensions: xq, yh
     ! long_name: 0 if land, 1 if ocean at zonal velocity (Cu) points
     ! units: none
 "wet_v"  [Used]
     ! modules: ocean_model
+    ! dimensions: xh, yq
     ! long_name: 0 if land, 1 if ocean at meridional velocity (Cv) points
     ! units: none
 "Coriolis"  [Used]
     ! modules: ocean_model
+    ! dimensions: xq, yq
     ! long_name: Coriolis parameter at corner (Bu) points
     ! units: s-1
-"dxt"  [Used]
+"dxt"  [Unused]
     ! modules: ocean_model
+    ! dimensions: xh, yh
     ! long_name: Delta(x) at thickness/tracer points (meter)
     ! units: m
-"dyt"  [Used]
+"dyt"  [Unused]
     ! modules: ocean_model
+    ! dimensions: xh, yh
     ! long_name: Delta(y) at thickness/tracer points (meter)
     ! units: m
-"dxCu"  [Used]
+"dxCu"  [Unused]
     ! modules: ocean_model
+    ! dimensions: xq, yh
     ! long_name: Delta(x) at u points (meter)
     ! units: m
-"dyCu"  [Used]
+"dyCu"  [Unused]
     ! modules: ocean_model
+    ! dimensions: xq, yh
     ! long_name: Delta(y) at u points (meter)
     ! units: m
-"dxCv"  [Used]
+"dxCv"  [Unused]
     ! modules: ocean_model
+    ! dimensions: xh, yq
     ! long_name: Delta(x) at v points (meter)
     ! units: m
-"dyCv"  [Used]
+"dyCv"  [Unused]
     ! modules: ocean_model
+    ! dimensions: xh, yq
     ! long_name: Delta(y) at v points (meter)
     ! units: m
-"dyCuo"  [Used]
+"dyCuo"  [Unused]
     ! modules: ocean_model
+    ! dimensions: xq, yh
     ! long_name: Open meridional grid spacing at u points (meter)
     ! units: m
-"dxCvo"  [Used]
+"dxCvo"  [Unused]
     ! modules: ocean_model
+    ! dimensions: xh, yq
     ! long_name: Open zonal grid spacing at v points (meter)
     ! units: m
 "sin_rot"  [Used]
     ! modules: ocean_model
+    ! dimensions: xh, yh
     ! long_name: sine of the clockwise angle of the ocean grid north to true north
     ! units: none
 "cos_rot"  [Used]
     ! modules: ocean_model
+    ! dimensions: xh, yh
     ! long_name: cosine of the clockwise angle of the ocean grid north to true north
     ! units: none
 "area_t_percent"  [Unused]
     ! modules: ocean_model
+    ! dimensions: xh, yh
     ! long_name: Percentage of cell area covered by ocean
     ! units: %
     ! variants: {area_t_percent,sftof}
@@ -140,1329 +170,1555 @@
     ! variants: {C_p,cpocean}
 "MEKE"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Mesoscale Eddy Kinetic Energy
     ! units: m2 s-2
     ! cell_methods: xh:mean yh:mean area:mean
 "MEKE_KH"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: MEKE derived diffusivity
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "MEKE_KU"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: MEKE derived lateral viscosity
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "MEKE_AU"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: MEKE derived lateral biharmonic viscosity
     ! units: m4 s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "MEKE_Ue"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: MEKE derived eddy-velocity scale
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "MEKE_Ub"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: MEKE derived bottom eddy-velocity scale
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "MEKE_Ut"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: MEKE derived barotropic eddy-velocity scale
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "MEKE_src"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: MEKE energy source
     ! units: m2 s-3
     ! cell_methods: xh:mean yh:mean area:mean
 "MEKE_src_adv"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: MEKE energy source from the horizontal advection of MEKE
     ! units: m2 s-3
     ! cell_methods: xh:mean yh:mean area:mean
 "MEKE_src_btm_drag"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: MEKE energy source from the bottom drag acting on MEKE
     ! units: m2 s-3
     ! cell_methods: xh:mean yh:mean area:mean
 "MEKE_src_GM"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: MEKE energy source from the thickness mixing (GM scheme)
     ! units: m2 s-3
     ! cell_methods: xh:mean yh:mean area:mean
 "MEKE_decay"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: MEKE decay rate
     ! units: s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "MEKE_GM_src"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: MEKE energy available from thickness mixing
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "MEKE_mom_src"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: MEKE energy available from momentum
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "MEKE_mom_src_bh"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: MEKE energy available from the biharmonic dissipation of momentum
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "MEKE_GME_snk"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: MEKE energy lost to GME backscatter
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "MEKE_Le"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Eddy mixing length used in the MEKE derived eddy diffusivity
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
 "MEKE_Lrhines"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Rhines length scale used in the MEKE derived eddy diffusivity
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
 "MEKE_Leady"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Eady length scale used in the MEKE derived eddy diffusivity
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
 "MEKE_gamma_b"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Ratio of bottom-projected eddy velocity to column-mean eddy velocity
     ! units: nondim
     ! cell_methods: xh:mean yh:mean area:mean
 "MEKE_gamma_t"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Ratio of barotropic eddy velocity to column-mean eddy velocity
     ! units: nondim
     ! cell_methods: xh:mean yh:mean area:mean
 "KHMEKE_u"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Zonal diffusivity of MEKE
     ! units: m2 s-1
     ! cell_methods: xq:point yh:mean
 "KHMEKE_v"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Meridional diffusivity of MEKE
     ! units: m2 s-1
     ! cell_methods: xh:mean yq:point
 "MEKE_equilibrium"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Equilibrated Mesoscale Eddy Kinetic Energy
     ! units: m2 s-2
     ! cell_methods: xh:mean yh:mean area:mean
 "SN_u"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Inverse eddy time-scale, S*N, at u-points
     ! units: s-1
     ! cell_methods: xq:point yh:mean
 "SN_v"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Inverse eddy time-scale, S*N, at v-points
     ! units: s-1
     ! cell_methods: xh:mean yq:point
 "L2u"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Length scale squared for mixing coefficient, at u-points
     ! units: m2
     ! cell_methods: xq:point yh:mean
 "L2v"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Length scale squared for mixing coefficient, at v-points
     ! units: m2
     ! cell_methods: xh:mean yq:point
 "sqg_struct"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Vertical structure of SQG mode
     ! units: nondim
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {sqg_struct,sqg_struct_xyave}
 "khth_struct"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Vertical structure of thickness diffusivity
     ! units: nondim
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {khth_struct,khth_struct_xyave}
 "N2_u"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zi
     ! long_name: Square of Brunt-Vaisala frequency, N^2, at u-points, as used in Visbeck et al.
     ! units: s-2
     ! cell_methods: xq:point yh:mean zi:point
     ! variants: {N2_u,N2_u_xyave}
 "N2_v"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zi
     ! long_name: Square of Brunt-Vaisala frequency, N^2, at v-points, as used in Visbeck et al.
     ! units: s-2
     ! cell_methods: xh:mean yq:point zi:point
     ! variants: {N2_v,N2_v_xyave}
 "S2_u"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Depth average square of slope magnitude, S^2, at u-points, as used in Visbeck et al.
     ! units: nondim
     ! cell_methods: xq:point yh:mean
 "S2_v"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Depth average square of slope magnitude, S^2, at v-points, as used in Visbeck et al.
     ! units: nondim
     ! cell_methods: xh:mean yq:point
 "Res_fn"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Resolution function for scaling diffusivities
     ! units: nondim
     ! cell_methods: xh:mean yh:mean area:mean
 "Rd_dx"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Ratio between deformation radius and grid spacing
     ! units: m m-1
     ! cell_methods: xh:mean yh:mean area:mean
 "bbl_thick_u"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: BBL thickness at u points
     ! units: m
     ! cell_methods: xq:point yh:mean
 "kv_bbl_u"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: BBL viscosity at u points
     ! units: m2 s-1
     ! cell_methods: xq:point yh:mean
 "bbl_u"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: BBL mean u current
     ! units: m s-1
     ! cell_methods: xq:point yh:mean
 "bbl_thick_v"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: BBL thickness at v points
     ! units: m
     ! cell_methods: xh:mean yq:point
 "kv_bbl_v"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: BBL viscosity at v points
     ! units: m2 s-1
     ! cell_methods: xh:mean yq:point
 "bbl_v"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: BBL mean v current
     ! units: m s-1
     ! cell_methods: xh:mean yq:point
 "Rayleigh_u"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Rayleigh drag velocity at u points
     ! units: m s-1
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {Rayleigh_u,Rayleigh_u_xyave}
 "Rayleigh_v"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Rayleigh drag velocity at v points
     ! units: m s-1
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {Rayleigh_v,Rayleigh_v_xyave}
 "uhGM"  [Used]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Time Mean Diffusive Zonal Thickness Flux
     ! units: kg s-1
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {uhGM,uhGM_xyave}
 "vhGM"  [Used]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Time Mean Diffusive Meridional Thickness Flux
     ! units: kg s-1
     ! cell_methods: xh:sum yq:point zl:sum
     ! variants: {vhGM,vhGM_xyave}
-"GMwork"  [Used] (CMOR equivalent is "tnkebto")
+"GMwork"  [Unused] (CMOR equivalent is "tnkebto")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Integrated Tendency of Ocean Mesoscale Eddy KE from Parameterized Eddy Advection
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {GMwork,tnkebto}
 "KHTH_u"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zi
     ! long_name: Parameterized mesoscale eddy advection diffusivity at U-point
     ! units: m2 s-1
     ! cell_methods: xq:point yh:mean zi:point
     ! variants: {KHTH_u,KHTH_u_xyave}
 "KHTH_v"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zi
     ! long_name: Parameterized mesoscale eddy advection diffusivity at V-point
     ! units: m2 s-1
     ! cell_methods: xh:mean yq:point zi:point
     ! variants: {KHTH_v,KHTH_v_xyave}
-"KHTH_t"  [Unused] (CMOR equivalent is "diftrblo")
+"KHTH_t"  [Used] (CMOR equivalent is "diftrblo")
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Ocean Tracer Diffusivity due to Parameterized Mesoscale Advection
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {KHTH_t,KHTH_t_xyave,diftrblo,diftrblo_xyave}
 "KHTH_u1"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Parameterized mesoscale eddy advection diffusivity at U-points (2-D)
     ! units: m2 s-1
     ! cell_methods: xq:point yh:mean
 "KHTH_v1"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Parameterized mesoscale eddy advection diffusivity at V-points (2-D)
     ! units: m2 s-1
     ! cell_methods: xh:mean yq:point
 "KHTH_t1"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Parameterized mesoscale eddy advection diffusivity at T-points (2-D)
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "neutral_slope_x"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zi
     ! long_name: Zonal slope of neutral surface
     ! units: nondim
     ! cell_methods: xq:point yh:mean zi:point
     ! variants: {neutral_slope_x,neutral_slope_x_xyave}
 "neutral_slope_y"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zi
     ! long_name: Meridional slope of neutral surface
     ! units: nondim
     ! cell_methods: xh:mean yq:point zi:point
     ! variants: {neutral_slope_y,neutral_slope_y_xyave}
 "GM_sfn_x"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zi
     ! long_name: Parameterized Zonal Overturning Streamfunction
     ! units: m3 s-1
     ! cell_methods: xq:point yh:mean zi:point
     ! variants: {GM_sfn_x,GM_sfn_x_xyave}
 "GM_sfn_y"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zi
     ! long_name: Parameterized Meridional Overturning Streamfunction
     ! units: m3 s-1
     ! cell_methods: xh:mean yq:point zi:point
     ! variants: {GM_sfn_y,GM_sfn_y_xyave}
 "GM_sfn_unlim_x"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zi
     ! long_name: Parameterized Zonal Overturning Streamfunction before limiting/smoothing
     ! units: m3 s-1
     ! cell_methods: xq:point yh:mean zi:point
     ! variants: {GM_sfn_unlim_x,GM_sfn_unlim_x_xyave}
 "GM_sfn_unlim_y"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zi
     ! long_name: Parameterized Meridional Overturning Streamfunction before limiting/smoothing
     ! units: m3 s-1
     ! cell_methods: xh:mean yq:point zi:point
     ! variants: {GM_sfn_unlim_y,GM_sfn_unlim_y_xyave}
 "RV"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yq, zl
     ! long_name: Relative Vorticity
     ! units: s-1
     ! cell_methods: xq:point yq:point zl:mean
 "PV"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yq, zl
     ! long_name: Potential Vorticity
     ! units: m-1 s-1
     ! cell_methods: xq:point yq:point zl:mean
 "gKEu"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Zonal Acceleration from Grad. Kinetic Energy
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {gKEu,gKEu_xyave}
 "gKEv"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Meridional Acceleration from Grad. Kinetic Energy
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {gKEv,gKEv_xyave}
 "rvxu"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Meridional Acceleration from Relative Vorticity
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {rvxu,rvxu_xyave}
 "rvxv"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Zonal Acceleration from Relative Vorticity
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {rvxv,rvxv_xyave}
 "CAu_Stokes"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Zonal Acceleration from Stokes Vorticity
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {CAu_Stokes,CAu_Stokes_xyave}
 "CAv_Stokes"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Meridional Acceleration from Stokes Vorticity
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {CAv_Stokes,CAv_Stokes_xyave}
 "hf_gKEu_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Depth-sum Fractional Thickness-weighted Zonal Acceleration from Grad. Kinetic Energy
     ! units: m s-2
     ! cell_methods: xq:point yh:mean
 "hf_gKEv_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Depth-sum Fractional Thickness-weighted Meridional Acceleration from Grad. Kinetic Energy
     ! units: m s-2
     ! cell_methods: xh:mean yq:point
 "h_gKEu"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Thickness Multiplied Zonal Acceleration from Grad. Kinetic Energy
     ! units: m2 s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {h_gKEu,h_gKEu_xyave}
 "intz_gKEu_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Depth-integral of Zonal Acceleration from Grad. Kinetic Energy
     ! units: m2 s-2
     ! cell_methods: xq:point yh:mean
 "h_gKEv"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Thickness Multiplied Meridional Acceleration from Grad. Kinetic Energy
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {h_gKEv,h_gKEv_xyave}
 "intz_gKEv_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Depth-integral of Meridional Acceleration from Grad. Kinetic Energy
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point
 "hf_rvxu_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Depth-sum Fractional Thickness-weighted Meridional Acceleration from Relative Vorticity
     ! units: m s-2
     ! cell_methods: xh:mean yq:point
 "hf_rvxv_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Depth-sum Fractional Thickness-weighted Zonal Acceleration from Relative Vorticity
     ! units: m s-2
     ! cell_methods: xq:point yh:mean
 "h_rvxu"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Thickness Multiplied Meridional Acceleration from Relative Vorticity
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {h_rvxu,h_rvxu_xyave}
 "intz_rvxu_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Depth-integral of Meridional Acceleration from Relative Vorticity
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point
 "h_rvxv"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Thickness Multiplied Zonal Acceleration from Relative Vorticity
     ! units: m2 s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {h_rvxv,h_rvxv_xyave}
 "intz_rvxv_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Depth-integral of Fractional Thickness-weighted Zonal Acceleration from Relative Vorticity
     ! units: m2 s-2
     ! cell_methods: xq:point yh:mean
 "MassWt_u"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: The fractional mass weighting at u-point PGF calculations
     ! units: nondim
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {MassWt_u,MassWt_u_xyave}
 "MassWt_v"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: The fractional mass weighting at v-point PGF calculations
     ! units: nondim
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {MassWt_v,MassWt_v_xyave}
 "NoSt"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Normal Stress
     ! units: s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {NoSt,NoSt_xyave}
 "ShSt"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yq, zl
     ! long_name: Shear Stress
     ! units: s-1
     ! cell_methods: xq:point yq:point zl:mean
 "diffu"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Zonal Acceleration from Horizontal Viscosity
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {diffu,diffu_xyave}
 "diffv"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Meridional Acceleration from Horizontal Viscosity
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {diffv,diffv_xyave}
 "hf_diffu_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Depth-sum Fractional Thickness-weighted Zonal Acceleration from Horizontal Viscosity
     ! units: m s-2
     ! cell_methods: xq:point yh:mean
 "hf_diffv_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Depth-sum Fractional Thickness-weighted Meridional Acceleration from Horizontal Viscosity
     ! units: m s-2
     ! cell_methods: xh:mean yq:point
 "h_diffu"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Thickness Multiplied Zonal Acceleration from Horizontal Viscosity
     ! units: m2 s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {h_diffu,h_diffu_xyave}
 "h_diffv"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Thickness Multiplied Meridional Acceleration from Horizontal Viscosity
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {h_diffv,h_diffv_xyave}
 "intz_diffu_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Depth-integral of Zonal Acceleration from Horizontal Viscosity
     ! units: m2 s-2
     ! cell_methods: xq:point yh:mean
 "intz_diffv_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Depth-integral of Meridional Acceleration from Horizontal Viscosity
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point
 "diffu_visc_rem"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Zonal Acceleration from Horizontal Viscosity multiplied by viscous remnant
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {diffu_visc_rem,diffu_visc_rem_xyave}
 "diffv_visc_rem"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Meridional Acceleration from Horizontal Viscosity multiplied by viscous remnant
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {diffv_visc_rem,diffv_visc_rem_xyave}
-"Ahh"  [Unused] (CMOR equivalent is "difmxybo")
+"Ahh"  [Used] (CMOR equivalent is "difmxybo")
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Biharmonic Horizontal Viscosity at h Points
     ! units: m4 s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {Ahh,Ahh_xyave,difmxybo,difmxybo_xyave}
 "Ahq"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yq, zl
     ! long_name: Biharmonic Horizontal Viscosity at q Points
     ! units: m4 s-1
     ! cell_methods: xq:point yq:point zl:mean
 "grid_Re_Ah"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Grid Reynolds number for the Biharmonic horizontal viscosity at h points
     ! units: nondim
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {grid_Re_Ah,grid_Re_Ah_xyave}
-"Khh"  [Unused] (CMOR equivalent is "difmxylo")
+"Khh"  [Used] (CMOR equivalent is "difmxylo")
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Laplacian Horizontal Viscosity at h Points
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {Khh,Khh_xyave,difmxylo,difmxylo_xyave}
 "Khq"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yq, zl
     ! long_name: Laplacian Horizontal Viscosity at q Points
     ! units: m2 s-1
     ! cell_methods: xq:point yq:point zl:mean
 "grid_Re_Kh"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Grid Reynolds number for the Laplacian horizontal viscosity at h points
     ! units: nondim
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {grid_Re_Kh,grid_Re_Kh_xyave}
 "vort_xy_q"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yq, zl
     ! long_name: Vertical vorticity at q Points
     ! units: s-1
     ! cell_methods: xq:point yq:point zl:mean
 "div_xx_h"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Horizontal divergence at h Points
     ! units: s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {div_xx_h,div_xx_h_xyave}
 "sh_xy_q"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yq, zl
     ! long_name: Shearing strain at q Points
     ! units: s-1
     ! cell_methods: xq:point yq:point zl:mean
 "sh_xx_h"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Horizontal tension at h Points
     ! units: s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {sh_xx_h,sh_xx_h_xyave}
 "FrictWork"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Integral work done by lateral friction terms. If GME is turned on, this includes the GME contribution.
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {FrictWork,FrictWork_xyave}
 "FrictWorkIntz"  [Unused] (CMOR equivalent is "dispkexyfo")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Depth integrated work done by lateral friction
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {FrictWorkIntz,dispkexyfo}
 "FrictWork_bh"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Integral work done by the biharmonic lateral friction terms.
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {FrictWork_bh,FrictWork_bh_xyave}
 "FrictWorkIntz_bh"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Depth integrated work done by the biharmonic lateral friction
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "Kv_slow"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Slow varying vertical viscosity
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {Kv_slow,Kv_slow_xyave}
 "Kv_u"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Total vertical viscosity at u-points
     ! units: m2 s-1
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {Kv_u,Kv_u_xyave}
 "Kv_v"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Total vertical viscosity at v-points
     ! units: m2 s-1
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {Kv_v,Kv_v_xyave}
 "Kv_gl90_u"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: GL90 vertical viscosity at u-points
     ! units: m2 s-1
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {Kv_gl90_u,Kv_gl90_u_xyave}
 "Kv_gl90_v"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: GL90 vertical viscosity at v-points
     ! units: m2 s-1
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {Kv_gl90_v,Kv_gl90_v_xyave}
 "au_visc"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zi
     ! long_name: Zonal Viscous Vertical Coupling Coefficient
     ! units: m s-1
     ! cell_methods: xq:point yh:mean zi:point
     ! variants: {au_visc,au_visc_xyave}
 "av_visc"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zi
     ! long_name: Meridional Viscous Vertical Coupling Coefficient
     ! units: m s-1
     ! cell_methods: xh:mean yq:point zi:point
     ! variants: {av_visc,av_visc_xyave}
 "au_gl90_visc"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zi
     ! long_name: Zonal Viscous Vertical GL90 Coupling Coefficient
     ! units: m s-1
     ! cell_methods: xq:point yh:mean zi:point
     ! variants: {au_gl90_visc,au_gl90_visc_xyave}
 "av_gl90_visc"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zi
     ! long_name: Meridional Viscous Vertical GL90 Coupling Coefficient
     ! units: m s-1
     ! cell_methods: xh:mean yq:point zi:point
     ! variants: {av_gl90_visc,av_gl90_visc_xyave}
 "Hu_visc"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Thickness at Zonal Velocity Points for Viscosity
     ! units: m
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {Hu_visc,Hu_visc_xyave}
 "Hv_visc"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Thickness at Meridional Velocity Points for Viscosity
     ! units: m
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {Hv_visc,Hv_visc_xyave}
 "HMLu_visc"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Mixed Layer Thickness at Zonal Velocity Points for Viscosity
     ! units: m
     ! cell_methods: xq:point yh:mean
 "HMLv_visc"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Mixed Layer Thickness at Meridional Velocity Points for Viscosity
     ! units: m
     ! cell_methods: xh:mean yq:point
-"FPw2x"  [Unused]
-    ! modules: {ocean_model,ocean_model_d2}
-    ! long_name: Wind direction from x-axis
-    ! units: radians
-    ! cell_methods: xh:mean yh:mean area:mean
-"tauFP_u"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
-    ! long_name: Stress Mag Profile  (u-points)
-    ! units: m2 s-2
-    ! cell_methods: xq:point yh:mean zi:point
-    ! variants: {tauFP_u,tauFP_u_xyave}
-"tauFP_v"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
-    ! long_name: Stress Mag Profile  (v-points)
-    ! units: m2 s-2
-    ! cell_methods: xh:mean yq:point zi:point
-    ! variants: {tauFP_v,tauFP_v_xyave}
-"FPtau2s_u"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
-    ! long_name: stress from shear direction (u-points)
-    ! units: radians
-    ! cell_methods: xq:point yh:mean zi:point
-    ! variants: {FPtau2s_u,FPtau2s_u_xyave}
-"FPtau2s_v"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
-    ! long_name: stress from shear direction (v-points)
-    ! units: radians
-    ! cell_methods: xh:mean yq:point zi:point
-    ! variants: {FPtau2s_v,FPtau2s_v_xyave}
-"FPtau2w_u"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
-    ! long_name: stress from wind  direction (u-points)
-    ! units: radians
-    ! cell_methods: xq:point yh:mean zi:point
-    ! variants: {FPtau2w_u,FPtau2w_u_xyave}
-"FPtau2w_v"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
-    ! long_name: stress from wind  direction (v-points)
-    ! units: radians
-    ! cell_methods: xh:mean yq:point zi:point
-    ! variants: {FPtau2w_v,FPtau2w_v_xyave}
 "du_dt_visc"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Zonal Acceleration from Vertical Viscosity
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {du_dt_visc,du_dt_visc_xyave}
 "dv_dt_visc"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Meridional Acceleration from Vertical Viscosity
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {dv_dt_visc,dv_dt_visc_xyave}
 "GLwork"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Sign-definite Kinetic Energy Source from GL90 Vertical Viscosity
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {GLwork,GLwork_xyave}
 "du_dt_visc_gl90"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Zonal Acceleration from GL90 Vertical Viscosity
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {du_dt_visc_gl90,du_dt_visc_gl90_xyave}
 "dv_dt_visc_gl90"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Meridional Acceleration from GL90 Vertical Viscosity
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {dv_dt_visc_gl90,dv_dt_visc_gl90_xyave}
 "du_dt_str"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Zonal Acceleration from Surface Wind Stresses
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {du_dt_str,du_dt_str_xyave}
 "dv_dt_str"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Meridional Acceleration from Surface Wind Stresses
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {dv_dt_str,dv_dt_str_xyave}
 "taux_bot"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Zonal Bottom Stress from Ocean to Earth
     ! units: Pa
     ! cell_methods: xq:point yh:mean
 "tauy_bot"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Meridional Bottom Stress from Ocean to Earth
     ! units: Pa
     ! cell_methods: xh:mean yq:point
 "hf_du_dt_visc_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Depth-sum Fractional Thickness-weighted Zonal Acceleration from Vertical Viscosity
     ! units: m s-2
     ! cell_methods: xq:point yh:mean
 "hf_dv_dt_visc_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Depth-sum Fractional Thickness-weighted Meridional Acceleration from Vertical Viscosity
     ! units: m s-2
     ! cell_methods: xh:mean yq:point
 "h_du_dt_visc"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Thickness Multiplied Zonal Acceleration from Horizontal Viscosity
     ! units: m2 s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {h_du_dt_visc,h_du_dt_visc_xyave}
 "h_dv_dt_visc"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Thickness Multiplied Meridional Acceleration from Horizontal Viscosity
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {h_dv_dt_visc,h_dv_dt_visc_xyave}
 "h_du_dt_str"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Thickness Multiplied Zonal Acceleration from Surface Wind Stresses
     ! units: m2 s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {h_du_dt_str,h_du_dt_str_xyave}
 "h_dv_dt_str"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Thickness Multiplied Meridional Acceleration from Surface Wind Stresses
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {h_dv_dt_str,h_dv_dt_str_xyave}
 "du_dt_str_visc_rem"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Zonal Acceleration from Surface Wind Stresses multiplied by viscous remnant
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {du_dt_str_visc_rem,du_dt_str_visc_rem_xyave}
 "dv_dt_str_visc_rem"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Meridional Acceleration from Surface Wind Stresses multiplied by viscous remnant
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {dv_dt_str_visc_rem,dv_dt_str_visc_rem_xyave}
 "PFuBT"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Zonal Anomalous Barotropic Pressure Force Acceleration
     ! units: m s-2
     ! cell_methods: xq:point yh:mean
 "PFvBT"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Meridional Anomalous Barotropic Pressure Force Acceleration
     ! units: m s-2
     ! cell_methods: xh:mean yq:point
 "CoruBT"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Zonal Barotropic Coriolis Acceleration
     ! units: m s-2
     ! cell_methods: xq:point yh:mean
 "CorvBT"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Meridional Barotropic Coriolis Acceleration
     ! units: m s-2
     ! cell_methods: xh:mean yq:point
 "u_accel_bt"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Barotropic zonal acceleration
     ! units: m s-2
     ! cell_methods: xq:point yh:mean
 "v_accel_bt"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Barotropic meridional acceleration
     ! units: m s-2
     ! cell_methods: xh:mean yq:point
 "ubtforce"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Barotropic zonal acceleration from baroclinic terms
     ! units: m s-2
     ! cell_methods: xq:point yh:mean
 "vbtforce"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Barotropic meridional acceleration from baroclinic terms
     ! units: m s-2
     ! cell_methods: xh:mean yq:point
 "ubt_dt"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Barotropic zonal acceleration
     ! units: m s-2
     ! cell_methods: xq:point yh:mean
 "vbt_dt"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Barotropic meridional acceleration
     ! units: m s-2
     ! cell_methods: xh:mean yq:point
 "eta_bt"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Barotropic end SSH
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
 "ubt"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Barotropic end zonal velocity
     ! units: m s-1
     ! cell_methods: xq:point yh:mean
 "vbt"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Barotropic end meridional velocity
     ! units: m s-1
     ! cell_methods: xh:mean yq:point
 "eta_st"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Barotropic start SSH
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
 "ubt_st"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Barotropic start zonal velocity
     ! units: m s-1
     ! cell_methods: xq:point yh:mean
 "vbt_st"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Barotropic start meridional velocity
     ! units: m s-1
     ! cell_methods: xh:mean yq:point
 "ubtav"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Barotropic time-average zonal velocity
     ! units: m s-1
     ! cell_methods: xq:point yh:mean
 "vbtav"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Barotropic time-average meridional velocity
     ! units: m s-1
     ! cell_methods: xh:mean yq:point
 "eta_cor"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Corrective mass flux within a timestep
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
 "visc_rem_u"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Viscous remnant at u
     ! units: nondim
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {visc_rem_u,visc_rem_u_xyave}
 "visc_rem_v"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Viscous remnant at v
     ! units: nondim
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {visc_rem_v,visc_rem_v_xyave}
 "gtot_n"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: gtot to North
     ! units: m s-2
     ! cell_methods: xh:mean yh:mean area:mean
 "gtot_s"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: gtot to South
     ! units: m s-2
     ! cell_methods: xh:mean yh:mean area:mean
 "gtot_e"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: gtot to East
     ! units: m s-2
     ! cell_methods: xh:mean yh:mean area:mean
 "gtot_w"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: gtot to West
     ! units: m s-2
     ! cell_methods: xh:mean yh:mean area:mean
 "eta_hifreq"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: High Frequency Barotropic SSH
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
 "ubt_hifreq"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: High Frequency Barotropic zonal velocity
     ! units: m s-1
     ! cell_methods: xq:point yh:mean
 "vbt_hifreq"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: High Frequency Barotropic meridional velocity
     ! units: m s-1
     ! cell_methods: xh:mean yq:point
 "eta_pred_hifreq"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: High Frequency Predictor Barotropic SSH
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
 "uhbt_hifreq"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: High Frequency Barotropic zonal transport
     ! units: m3 s-1
     ! cell_methods: xq:point yh:mean
 "vhbt_hifreq"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: High Frequency Barotropic meridional transport
     ! units: m3 s-1
     ! cell_methods: xh:mean yq:point
 "frhatu"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Fractional thickness of layers in u-columns
     ! units: nondim
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {frhatu,frhatu_xyave}
 "frhatv"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Fractional thickness of layers in v-columns
     ! units: nondim
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {frhatv,frhatv_xyave}
 "frhatu1"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Predictor Fractional thickness of layers in u-columns
     ! units: nondim
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {frhatu1,frhatu1_xyave}
 "frhatv1"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Predictor Fractional thickness of layers in v-columns
     ! units: nondim
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {frhatv1,frhatv1_xyave}
-"uhbt"  [Unused]
+"uhbt"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Barotropic zonal transport averaged over a baroclinic step
     ! units: m3 s-1
     ! cell_methods: xq:point yh:mean
-"vhbt"  [Unused]
+"vhbt"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Barotropic meridional transport averaged over a baroclinic step
     ! units: m3 s-1
     ! cell_methods: xh:mean yq:point
 "BTC_FA_u_EE"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: BTCont type far east face area
     ! units: m2
     ! cell_methods: xq:point yh:mean
 "BTC_FA_u_E0"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: BTCont type near east face area
     ! units: m2
     ! cell_methods: xq:point yh:mean
 "BTC_FA_u_WW"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: BTCont type far west face area
     ! units: m2
     ! cell_methods: xq:point yh:mean
 "BTC_FA_u_W0"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: BTCont type near west face area
     ! units: m2
     ! cell_methods: xq:point yh:mean
 "BTC_ubt_EE"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: BTCont type far east velocity
     ! units: m s-1
     ! cell_methods: xq:point yh:mean
 "BTC_ubt_WW"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: BTCont type far west velocity
     ! units: m s-1
     ! cell_methods: xq:point yh:mean
 "BTC_FA_v_NN"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: BTCont type far north face area
     ! units: m2
     ! cell_methods: xh:mean yq:point
 "BTC_FA_v_N0"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: BTCont type near north face area
     ! units: m2
     ! cell_methods: xh:mean yq:point
 "BTC_FA_v_SS"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: BTCont type far south face area
     ! units: m2
     ! cell_methods: xh:mean yq:point
 "BTC_FA_v_S0"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: BTCont type near south face area
     ! units: m2
     ! cell_methods: xh:mean yq:point
 "BTC_vbt_NN"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: BTCont type far north velocity
     ! units: m s-1
     ! cell_methods: xh:mean yq:point
 "BTC_vbt_SS"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: BTCont type far south velocity
     ! units: m s-1
     ! cell_methods: xh:mean yq:point
 "uhbt0"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Barotropic zonal transport difference
     ! units: m3 s-1
     ! cell_methods: xq:point yh:mean
 "vhbt0"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Barotropic meridional transport difference
     ! units: m3 s-1
     ! cell_methods: xh:mean yq:point
+"SSH_u_OBC"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
+    ! long_name: Outer sea surface height at u OBC points
+    ! units: m
+    ! cell_methods: xq:point yh:mean
+"SSH_v_OBC"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
+    ! long_name: Outer sea surface height at v OBC points
+    ! units: m
+    ! cell_methods: xh:mean yq:point
+"ubt_OBC"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
+    ! long_name: Outer u velocity at OBC points
+    ! units: m
+    ! cell_methods: xq:point yh:mean
+"vbt_OBC"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
+    ! long_name: Outer v velocity at OBC points
+    ! units: m
+    ! cell_methods: xh:mean yq:point
 "uh"  [Used]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Zonal Thickness Flux
     ! units: m3 s-1
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {uh,uh_xyave}
 "vh"  [Used]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Meridional Thickness Flux
     ! units: m3 s-1
     ! cell_methods: xh:sum yq:point zl:sum
     ! variants: {vh,vh_xyave}
 "CAu"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Zonal Coriolis and Advective Acceleration
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {CAu,CAu_xyave}
 "CAv"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Meridional Coriolis and Advective Acceleration
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {CAv,CAv_xyave}
 "PFu"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Zonal Pressure Force Acceleration
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {PFu,PFu_xyave}
 "PFv"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Meridional Pressure Force Acceleration
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {PFv,PFv_xyave}
 "ueffA"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Effective U-Face Area
     ! units: m^2
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {ueffA,ueffA_xyave}
 "veffA"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Effective V-Face Area
     ! units: m^2
     ! cell_methods: xh:sum yq:point zl:sum
     ! variants: {veffA,veffA_xyave}
 "deta_dt"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Barotropic SSH tendency due to dynamics
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "hf_PFu_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Depth-sum Fractional Thickness-weighted Zonal Pressure Force Acceleration
     ! units: m s-2
     ! cell_methods: xq:point yh:mean
 "hf_PFv_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Depth-sum Fractional Thickness-weighted Meridional Pressure Force Acceleration
     ! units: m s-2
     ! cell_methods: xh:mean yq:point
 "h_PFu"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Thickness Multiplied Zonal Pressure Force Acceleration
     ! units: m2 s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {h_PFu,h_PFu_xyave}
 "h_PFv"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Thickness Multiplied Meridional Pressure Force Acceleration
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {h_PFv,h_PFv_xyave}
 "intz_PFu_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Depth-integral of Zonal Pressure Force Acceleration
     ! units: m2 s-2
     ! cell_methods: xq:point yh:mean
 "intz_PFv_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Depth-integral of Meridional Pressure Force Acceleration
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point
 "hf_CAu_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Depth-sum Fractional Thickness-weighted Zonal Coriolis and Advective Acceleration
     ! units: m s-2
     ! cell_methods: xq:point yh:mean
 "hf_CAv_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Depth-sum Fractional Thickness-weighted Meridional Coriolis and Advective Acceleration
     ! units: m s-2
     ! cell_methods: xh:mean yq:point
 "h_CAu"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Thickness Multiplied Zonal Coriolis and Advective Acceleration
     ! units: m2 s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {h_CAu,h_CAu_xyave}
 "h_CAv"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Thickness Multiplied Meridional Coriolis and Advective Acceleration
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {h_CAv,h_CAv_xyave}
 "intz_CAu_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Depth-integral of Zonal Coriolis and Advective Acceleration
     ! units: m2 s-2
     ! cell_methods: xq:point yh:mean
 "intz_CAv_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Depth-integral of Meridional Coriolis and Advective Acceleration
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point
 "uav"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Barotropic-step Averaged Zonal Velocity
     ! units: m s-1
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {uav,uav_xyave}
 "vav"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Barotropic-step Averaged Meridional Velocity
     ! units: m s-1
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {vav,vav_xyave}
 "u_BT_accel"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Barotropic Anomaly Zonal Acceleration
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {u_BT_accel,u_BT_accel_xyave}
 "v_BT_accel"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Barotropic Anomaly Meridional Acceleration
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {v_BT_accel,v_BT_accel_xyave}
 "hf_u_BT_accel_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Depth-sum Fractional Thickness-weighted Barotropic Anomaly Zonal Acceleration
     ! units: m s-2
     ! cell_methods: xq:point yh:mean
 "hf_v_BT_accel_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Depth-sum Fractional Thickness-weighted Barotropic Anomaly Meridional Acceleration
     ! units: m s-2
     ! cell_methods: xh:mean yq:point
 "h_u_BT_accel"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Thickness Multiplied Barotropic Anomaly Zonal Acceleration
     ! units: m2 s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {h_u_BT_accel,h_u_BT_accel_xyave}
 "h_v_BT_accel"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Thickness Multiplied Barotropic Anomaly Meridional Acceleration
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {h_v_BT_accel,h_v_BT_accel_xyave}
 "intz_u_BT_accel_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Depth-integral of Barotropic Anomaly Zonal Acceleration
     ! units: m2 s-2
     ! cell_methods: xq:point yh:mean
 "intz_v_BT_accel_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Depth-integral of Barotropic Anomaly Meridional Acceleration
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point
 "PFu_visc_rem"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Zonal Pressure Force Acceleration multiplied by the viscous remnant
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {PFu_visc_rem,PFu_visc_rem_xyave}
 "PFv_visc_rem"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Meridional Pressure Force Acceleration multiplied by the viscous remnant
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {PFv_visc_rem,PFv_visc_rem_xyave}
 "CAu_visc_rem"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Zonal Coriolis and Advective Acceleration multiplied by the viscous remnant
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {CAu_visc_rem,CAu_visc_rem_xyave}
 "CAv_visc_rem"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Meridional Coriolis and Advective Acceleration multiplied by the viscous remnant
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {CAv_visc_rem,CAv_visc_rem_xyave}
 "u_BT_accel_visc_rem"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Barotropic Anomaly Zonal Acceleration multiplied by the viscous remnant
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {u_BT_accel_visc_rem,u_BT_accel_visc_rem_xyave}
 "v_BT_accel_visc_rem"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Barotropic Anomaly Meridional Acceleration multiplied by the viscous remnant
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {v_BT_accel_visc_rem,v_BT_accel_visc_rem_xyave}
-"uhml"  [Unused]
+"uhml"  [Used]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Zonal Thickness Flux to Restratify Mixed Layer
     ! units: kg s-1
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {uhml,uhml_xyave}
-"vhml"  [Unused]
+"vhml"  [Used]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Meridional Thickness Flux to Restratify Mixed Layer
     ! units: kg s-1
     ! cell_methods: xh:sum yq:point zl:sum
     ! variants: {vhml,vhml_xyave}
 "MLu_restrat_time"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Mixed Layer Zonal Restratification Timescale
     ! units: s
     ! cell_methods: xq:point yh:mean
 "MLv_restrat_time"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Mixed Layer Meridional Restratification Timescale
     ! units: s
     ! cell_methods: xh:mean yq:point
 "MLD_restrat"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Mixed Layer Depth as used in the mixed-layer restratification parameterization
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
 "BLD_restrat"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Boundary Layer Depth as used in the mixed-layer restratification parameterization
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
 "ML_buoy_restrat"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Mixed Layer Buoyancy as used in the mixed-layer restratification parameterization
     ! units: m s-2
     ! cell_methods: xh:mean yh:mean area:mean
 "udml_restrat"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Transport stream function amplitude for zonal restratification of mixed layer
     ! units: m3 s-1
     ! cell_methods: xq:point yh:mean
 "vdml_restrat"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Transport stream function amplitude for meridional restratification of mixed layer
     ! units: m3 s-1
     ! cell_methods: xh:mean yq:point
 "uml_restrat"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Surface zonal velocity component of mixed layer restratification
     ! units: m s-1
     ! cell_methods: xq:point yh:mean
 "vml_restrat"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Surface meridional velocity component of mixed layer restratification
     ! units: m s-1
     ! cell_methods: xh:mean yq:point
+"mle_fl"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Frontal length scale used in the mixed layer restratificiation parameterization
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
 "masscello"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Mass per unit area of liquid ocean grid cell
     ! units: kg m-2
     ! standard_name: sea_water_mass_per_unit_area
@@ -1470,11 +1726,13 @@
     ! variants: {masscello,masscello_xyave}
 "masso"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Mass of liquid ocean
     ! units: kg
     ! standard_name: sea_water_mass
-"thkcello"  [Used]
+"thkcello"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Cell Thickness
     ! units: m
     ! standard_name: cell_thickness
@@ -1482,24 +1740,28 @@
     ! variants: {thkcello,thkcello_xyave}
 "h_pre_sync"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Cell thickness from the previous timestep
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {h_pre_sync,h_pre_sync_xyave}
-"tob"  [Used]
+"tob"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Sea Water Potential Temperature at Sea Floor
     ! units: degC
     ! standard_name: sea_water_potential_temperature_at_sea_floor
     ! cell_methods: xh:mean yh:mean area:mean
 "sob"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Sea Water Salinity at Sea Floor
     ! units: psu
     ! standard_name: sea_water_salinity_at_sea_floor
     ! cell_methods: xh:mean yh:mean area:mean
 "tosq"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Square of Potential Temperature
     ! units: degC2
     ! standard_name: Potential Temperature Squared
@@ -1507,6 +1769,7 @@
     ! variants: {tosq,tosq_xyave}
 "sosq"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Square of Salinity
     ! units: psu2
     ! standard_name: Salinity Squared
@@ -1514,724 +1777,1367 @@
     ! variants: {sosq,sosq_xyave}
 "temp_layer_ave"  [Unused]
     ! modules: ocean_model
+    ! dimensions: zl
     ! long_name: Layer Average Ocean Temperature
     ! units: degC
     ! cell_methods: zl:mean
+"contemp_layer_ave"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: zl
+    ! long_name: Layer Average Ocean Conservative Temperature
+    ! units: Celsius
+    ! cell_methods: zl:mean
 "salt_layer_ave"  [Unused]
     ! modules: ocean_model
+    ! dimensions: zl
     ! long_name: Layer Average Ocean Salinity
     ! units: psu
     ! cell_methods: zl:mean
+"abssalt_layer_ave"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: zl
+    ! long_name: Layer Average Ocean Absolute Salinity
+    ! units: g kg-1
+    ! cell_methods: zl:mean
 "thetaoga"  [Used]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Global Mean Ocean Potential Temperature
     ! units: degC
     ! standard_name: sea_water_potential_temperature
+"bigthetaoga"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: scalar
+    ! long_name: Global Mean Ocean Conservative Temperature
+    ! units: Celsius
+    ! standard_name: sea_water_conservative_temperature
 "soga"  [Used]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Global Mean Ocean Salinity
     ! units: psu
     ! standard_name: sea_water_salinity
+"abssoga"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: scalar
+    ! long_name: Global Mean Ocean Absolute Salinity
+    ! units: g kg-1
+    ! standard_name: sea_water_absolute_salinity
 "sst_global"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Global Area Average Sea Surface Temperature
     ! units: degC
     ! standard_name: sea_surface_temperature
     ! variants: {sst_global,tosga}
+"sscont_global"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: scalar
+    ! long_name: Global Area Average Sea Surface Conservative Temperature
+    ! units: Celsius
+    ! standard_name: sea_surface_temperature
 "sss_global"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Global Area Average Sea Surface Salinity
     ! units: psu
     ! standard_name: sea_surface_salinity
     ! variants: {sss_global,sosga}
+"ssabss_global"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: scalar
+    ! long_name: Global Area Average Sea Surface Absolute Salinity
+    ! units: psu
+    ! standard_name: sea_surface_absolute_salinity
 "u"  [Used] (CMOR equivalent is "uo")
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Zonal velocity
     ! units: m s-1
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {u,u_xyave,uo,uo_xyave}
 "v"  [Used] (CMOR equivalent is "vo")
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Meridional velocity
     ! units: m s-1
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {v,v_xyave,vo,vo_xyave}
 "usq"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Zonal velocity squared
     ! units: m2 s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {usq,usq_xyave}
 "vsq"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Meridional velocity squared
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {vsq,vsq_xyave}
 "uv"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Product between zonal and meridional velocities at h-points
     ! units: m2 s-2
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {uv,uv_xyave}
 "h"  [Used]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Layer Thickness
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {h,h_xyave}
-"e"  [Unused]
+"e"  [Used]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Interface Height Relative to Mean Sea Level
     ! units: m
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {e,e_xyave}
 "e_D"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Interface Height above the Seafloor
     ! units: m
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {e_D,e_D_xyave}
 "Rml"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Mixed Layer Coordinate Potential Density
     ! units: kg m-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {Rml,Rml_xyave}
 "Rho_cv"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Coordinate Potential Density
     ! units: kg m-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {Rho_cv,Rho_cv_xyave}
-"rhopot0"  [Unused]
+"rhopot0"  [Used]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Potential density referenced to surface
     ! units: kg m-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {rhopot0,rhopot0_xyave}
-"rhopot2"  [Used]
+"rhopot2"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Potential density referenced to 2000 dbar
     ! units: kg m-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {rhopot2,rhopot2_xyave}
 "rhoinsitu"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: In situ density
     ! units: kg m-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {rhoinsitu,rhoinsitu_xyave}
 "drho_dT"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Partial derivative of rhoinsitu with respect to temperature (alpha)
     ! units: kg m-3 degC-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {drho_dT,drho_dT_xyave}
 "drho_dS"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Partial derivative of rhoinsitu with respect to salinity (beta)
     ! units: kg^2 g-1 m-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {drho_dS,drho_dS_xyave}
 "dudt"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Zonal Acceleration
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {dudt,dudt_xyave}
 "dvdt"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Meridional Acceleration
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {dvdt,dvdt_xyave}
 "dhdt"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Thickness tendency
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {dhdt,dhdt_xyave}
 "hf_dudt_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Depth-sum Fractional Thickness-weighted Zonal Acceleration
     ! units: m s-2
     ! cell_methods: xq:point yh:mean
 "hf_dvdt_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Depth-sum Fractional Thickness-weighted Meridional Acceleration
     ! units: m s-2
     ! cell_methods: xh:mean yq:point
 "h_du_dt"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Thickness Multiplied Zonal Acceleration
     ! units: m2 s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {h_du_dt,h_du_dt_xyave}
 "h_dv_dt"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Thickness Multiplied Meridional Acceleration
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {h_dv_dt,h_dv_dt_xyave}
 "h_rho"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Layer thicknesses in pure potential density coordinates
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {h_rho,h_rho_xyave}
 "uh_rho"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Zonal volume transport in pure potential density coordinates
     ! units: m3 s-1
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {uh_rho,uh_rho_xyave}
 "vh_rho"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Meridional volume transport in pure potential density coordinates
     ! units: m3 s-1
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {vh_rho,vh_rho_xyave}
 "uhGM_rho"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Zonal volume transport due to interface height diffusion in pure potential density coordinates
     ! units: m3 s-1
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {uhGM_rho,uhGM_rho_xyave}
 "vhGM_rho"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Meridional volume transport due to interface height diffusion in pure potential density coordinates
     ! units: m3 s-1
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {vhGM_rho,vhGM_rho_xyave}
 "KE"  [Used]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Layer kinetic energy per unit mass
     ! units: m2 s-2
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {KE,KE_xyave}
 "dKE_dt"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Kinetic Energy Tendency of Layer
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {dKE_dt,dKE_dt_xyave}
 "PE_to_KE"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Potential to Kinetic Energy Conversion of Layer
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {PE_to_KE,PE_to_KE_xyave}
 "KE_BT"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Barotropic contribution to Kinetic Energy
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {KE_BT,KE_BT_xyave}
+"PE_to_KE_btbc"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: Potential to Kinetic Energy Conversion of Layer (including barotropic solver contribution)
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {PE_to_KE_btbc,PE_to_KE_btbc_xyave}
+"KE_Coradv_btbc"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: Kinetic Energy Source from Coriolis and Advection (including barotropic solver contribution)
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {KE_Coradv_btbc,KE_Coradv_btbc_xyave}
+"KE_BTPF"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: Kinetic Energy Source from Barotropic Pressure Gradient Force.
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {KE_BTPF,KE_BTPF_xyave}
+"KE_BTCF"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: Kinetic Energy Source from Barotropic Coriolis Force.
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {KE_BTCF,KE_BTCF_xyave}
+"KE_BTWD"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: Kinetic Energy Source from Barotropic Linear Wave Drag.
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {KE_BTWD,KE_BTWD_xyave}
 "KE_Coradv"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Kinetic Energy Source from Coriolis and Advection
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {KE_Coradv,KE_Coradv_xyave}
 "KE_adv"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Kinetic Energy Source from Advection
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {KE_adv,KE_adv_xyave}
 "KE_visc"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Kinetic Energy Source from Vertical Viscosity and Stresses
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {KE_visc,KE_visc_xyave}
 "KE_visc_gl90"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Kinetic Energy Source from GL90 Vertical Viscosity
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {KE_visc_gl90,KE_visc_gl90_xyave}
 "KE_stress"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Kinetic Energy Source from Surface Stresses or Body Wind Stress
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {KE_stress,KE_stress_xyave}
 "KE_horvisc"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Kinetic Energy Source from Horizontal Viscosity
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {KE_horvisc,KE_horvisc_xyave}
 "KE_dia"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Kinetic Energy Source from Diapycnal Diffusion
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {KE_dia,KE_dia_xyave}
 "cg1"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: First baroclinic gravity wave speed
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "Rd1"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: First baroclinic deformation radius
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
 "CFL_cg1"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: CFL of first baroclinic gravity wave = dt*cg1*(1/dx+1/dy)
     ! units: nondim
     ! cell_methods: xh:mean yh:mean area:mean
 "CFL_cg1_x"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: i-component of CFL of first baroclinic gravity wave = dt*cg1*/dx
     ! units: nondim
     ! cell_methods: xh:mean yh:mean area:mean
 "CFL_cg1_y"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: j-component of CFL of first baroclinic gravity wave = dt*cg1*/dy
     ! units: nondim
     ! cell_methods: xh:mean yh:mean area:mean
 "cg_ebt"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Equivalent barotropic gravity wave speed
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "Rd_ebt"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Equivalent barotropic deformation radius
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
 "p_ebt"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Equivalent barotropic modal strcuture
     ! units: nondim
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {p_ebt,p_ebt_xyave}
-"mass_wt"  [Unused]
+"mass_wt"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: The column mass for calculating mass-weighted average properties
     ! units: kg m-2
     ! cell_methods: xh:mean yh:mean area:mean
-"temp_int"  [Unused] (CMOR equivalent is "opottempmint")
+"temp_int"  [Used] (CMOR equivalent is "opottempmint")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Density weighted column integrated potential temperature
     ! units: degC kg m-2
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {temp_int,opottempmint}
-"salt_int"  [Unused] (CMOR equivalent is "somint")
+"salt_int"  [Used] (CMOR equivalent is "somint")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Density weighted column integrated salinity
     ! units: psu kg m-2
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {salt_int,somint}
 "col_mass"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: The column integrated in situ density
     ! units: kg m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "col_height"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: The height of the water column
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
-"pbo"  [Used]
+"pbo"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Sea Water Pressure at Sea Floor
     ! units: Pa
     ! standard_name: sea_water_pressure_at_sea_floor
     ! cell_methods: xh:mean yh:mean area:mean
 "ea_t"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Layer (heat) entrainment from above per timestep
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {ea_t,ea_t_xyave}
 "eb_t"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Layer (heat) entrainment from below per timestep
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {eb_t,eb_t_xyave}
 "ea_s"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Layer (salt) entrainment from above per timestep
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {ea_s,ea_s_xyave}
 "eb_s"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Layer (salt) entrainment from below per timestep
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {eb_s,eb_s_xyave}
 "ea"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Layer entrainment from above per timestep
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {ea,ea_xyave}
 "eb"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Layer entrainment from below per timestep
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {eb,eb_xyave}
 "Tflx_dia_diff"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Diffusive diapycnal temperature flux across interfaces
     ! units: degC m s-1
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {Tflx_dia_diff,Tflx_dia_diff_xyave}
 "Sflx_dia_diff"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Diffusive diapycnal salnity flux across interfaces
     ! units: psu m s-1
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {Sflx_dia_diff,Sflx_dia_diff_xyave}
+"N2_diabatic"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
+    ! long_name: Squared buoyancy frequency diagnosed after diffusion applied in thermodynamic timestep.
+    ! units: s-2
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+    ! variants: {N2_diabatic,N2_diabatic_xyave}
+"N2_temp_diabatic"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
+    ! long_name: Squared buoyancy frequency due to temperature stratification diagnosed after diffusion applied in thermodynamic timestep.
+    ! units: s-2
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+    ! variants: {N2_temp_diabatic,N2_temp_diabatic_xyave}
+"N2_salt_diabatic"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
+    ! long_name: Squared buoyancy frequency due to salinity stratification diagnosed after diffusion applied in thermodynamic timestep.
+    ! units: s-2
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+    ! variants: {N2_salt_diabatic,N2_salt_diabatic_xyave}
 "MLD_003"  [Used] (CMOR equivalent is "mlotst")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Mixed layer depth (delta rho = 0.03)
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {MLD_003,mlotst}
 "mlotstsq"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Square of Ocean Mixed Layer Thickness Defined by Sigma T
     ! units: m2
     ! standard_name: square_of_ocean_mixed_layer_thickness_defined_by_sigma_t
     ! cell_methods: xh:mean yh:mean area:mean
 "MLD_0125"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Mixed layer depth (delta rho = 0.125)
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
 "MLD_EN1"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Mixed layer depth for energy value set to      25.00 J/m2 (Energy set by 1st MLD_EN_VALS)
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
 "MLD_EN2"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Mixed layer depth for energy value set to    2500.00 J/m2 (Energy set by 2nd MLD_EN_VALS)
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
 "MLD_EN3"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Mixed layer depth for energy value set to  250000.00 J/m2 (Energy set by 3rd MLD_EN_VALS)
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
 "subML_N2"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Squared buoyancy frequency below mixed layer
     ! units: s-2
     ! cell_methods: xh:mean yh:mean area:mean
 "MLD_user"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Mixed layer depth (used defined)
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
 "MLD_003_refZ"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Depth of reference density for MLD (delta rho = 0.03)
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
 "MLD_003_refRho"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Reference density for MLD (delta rho = 0.03)
     ! units: kg/m3
     ! cell_methods: xh:mean yh:mean area:mean
+"Bflx_dia_diff"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
+    ! long_name: Diffusive diapycnal buoyancy flux across interfaces
+    ! units: W m-3
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+    ! variants: {Bflx_dia_diff,Bflx_dia_diff_xyave}
+"Bflx_dia_diff_dz"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: Layerwise integral of diffusive diapycnal buoyancy flux.
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {Bflx_dia_diff_dz,Bflx_dia_diff_dz_xyave}
+"Bflx_dia_diff_idz"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Layer integrated diffusive diapycnal buoyancy flux.
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"Bflx_dia_diff_idV"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: scalar
+    ! long_name: Global integrated diffusive diapycnal buoyancy flux.
+    ! units: W
+"Bflx_salt_dia_diff"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
+    ! long_name: Salinity contribution to diffusive diapycnal buoyancy flux across interfaces
+    ! units: W m-3
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+    ! variants: {Bflx_salt_dia_diff,Bflx_salt_dia_diff_xyave}
+"Bflx_salt_dia_diff_dz"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: Salinity contribution to layer integral of diffusive diapycnal buoyancy flux.
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {Bflx_salt_dia_diff_dz,Bflx_salt_dia_diff_dz_xyave}
+"Bflx_salt_dia_diff_idz"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Salinity contribution to layer integrated diffusive diapycnal buoyancy flux.
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"Bflx_salt_dia_diff_idV"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: scalar
+    ! long_name: Salinity contribution to global integrated diffusive diapycnal buoyancy flux.
+    ! units: W
+"Bflx_temp_dia_diff"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
+    ! long_name: Temperature contribution to diffusive diapycnal buoyancy flux across interfaces
+    ! units: W m-3
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+    ! variants: {Bflx_temp_dia_diff,Bflx_temp_dia_diff_xyave}
+"Bflx_temp_dia_diff_dz"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: Temperature contribution to layer integral of diffusive diapycnal buoyancy flux.
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {Bflx_temp_dia_diff_dz,Bflx_temp_dia_diff_dz_xyave}
+"Bflx_temp_dia_diff_idz"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Temperature contribution to layer integrated diffusive diapycnal buoyancy flux.
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"Bflx_temp_dia_diff_idV"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: scalar
+    ! long_name: Temperature contribution to global integrated diffusive diapycnal buoyancy flux.
+    ! units: W
+"Bflx_dia_diff_BBL"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
+    ! long_name: Diffusive diapycnal buoyancy flux across interfaces due to the BBL parameterization.
+    ! units: W m-3
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+    ! variants: {Bflx_dia_diff_BBL,Bflx_dia_diff_BBL_xyave}
+"Bflx_dia_diff_dz_BBL"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: Layerwise integral of diffusive diapycnal buoyancy flux due to the BBL parameterization.
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {Bflx_dia_diff_dz_BBL,Bflx_dia_diff_dz_BBL_xyave}
+"Bflx_dia_diff_idz_BBL"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Layer integrated diffusive diapycnal buoyancy flux due to the BBL parameterization.
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"Bflx_dia_diff_idV_BBL"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: scalar
+    ! long_name: Global integrated diffusive diapycnal buoyancy flux due to BBL.
+    ! units: W
+"Bflx_dia_diff_ePBL"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
+    ! long_name: Diffusive diapycnal buoyancy flux across interfaces due to ePBL
+    ! units: W m-3
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+    ! variants: {Bflx_dia_diff_ePBL,Bflx_dia_diff_ePBL_xyave}
+"Bflx_dia_diff_dz_ePBL"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: Layerwise integral of diffusive diapycnal buoyancy flux due to ePBL.
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {Bflx_dia_diff_dz_ePBL,Bflx_dia_diff_dz_ePBL_xyave}
+"Bflx_dia_diff_idz_ePBL"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Layer integrated diffusive diapycnal buoyancy flux due to ePBL.
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"Bflx_dia_diff_idV_ePBL"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: scalar
+    ! long_name: Global integrated diffusive diapycnal buoyancy flux due to ePBL.
+    ! units: W
+"Bflx_dia_diff_KS"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
+    ! long_name: Diffusive diapycnal buoyancy flux across interfaces due to Kappa Shear
+    ! units: W m-3
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+    ! variants: {Bflx_dia_diff_KS,Bflx_dia_diff_KS_xyave}
+"Bflx_dia_diff_dz_KS"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: Layerwise integral of diffusive diapycnal buoyancy flux due to Kappa Shear.
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {Bflx_dia_diff_dz_KS,Bflx_dia_diff_dz_KS_xyave}
+"Bflx_dia_diff_idz_KS"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Layer integrated diffusive diapycnal buoyancy flux due to Kappa Shear.
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"Bflx_dia_diff_idV_KS"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: scalar
+    ! long_name: Global integrated diffusive diapycnal buoyancy flux due to Kappa Shear.
+    ! units: W
+"Bflx_dia_diff_bkgnd"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
+    ! long_name: Diffusive diapycnal buoyancy flux across interfaces due to bkgnd mixing
+    ! units: W m-3
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+    ! variants: {Bflx_dia_diff_bkgnd,Bflx_dia_diff_bkgnd_xyave}
+"Bflx_dia_diff_dz_bkgnd"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: Layerwise integral of diffusive diapycnal buoyancy flux due to bkgnd mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {Bflx_dia_diff_dz_bkgnd,Bflx_dia_diff_dz_bkgnd_xyave}
+"Bflx_dia_diff_idz_bkgnd"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Layer integrated diffusive diapycnal buoyancy flux due to bkgnd mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"Bflx_dia_diff_idV_bkgnd"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: scalar
+    ! long_name: Global integrated diffusive diapycnal buoyancy flux due to Kd_bkgnd.
+    ! units: W
+"Bflx_dia_diff_ddiff_heat"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
+    ! long_name: Diffusive diapycnal buoyancy flux across interfaces due to double diffusion of heat
+    ! units: W m-3
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+    ! variants: {Bflx_dia_diff_ddiff_heat,Bflx_dia_diff_ddiff_heat_xyave}
+"Bflx_dia_diff_dz_ddiff_heat"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: Layerwise integral of diffusive diapycnal buoyancy flux due to double diffusion of heat.
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {Bflx_dia_diff_dz_ddiff_heat,Bflx_dia_diff_dz_ddiff_heat_xyave}
+"Bflx_dia_diff_idz_ddiff_heat"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Layer integrated diffusive diapycnal buoyancy flux due to double diffusion of heat.
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"Bflx_dia_diff_idV_ddiff_heat"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: scalar
+    ! long_name: Global integrated diffusive diapycnal buoyancy flux due to double diffusion of heat.
+    ! units: W
+"Bflx_dia_diff_ddiff_salt"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
+    ! long_name: Diffusive diapycnal buoyancy flux across interfaces due to double diffusion of salt
+    ! units: W m-3
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+    ! variants: {Bflx_dia_diff_ddiff_salt,Bflx_dia_diff_ddiff_salt_xyave}
+"Bflx_dia_diff_dz_ddiff_salt"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: Layerwise integral of diffusive diapycnal buoyancy flux due to double diffusion of salt.
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {Bflx_dia_diff_dz_ddiff_salt,Bflx_dia_diff_dz_ddiff_salt_xyave}
+"Bflx_dia_diff_idz_ddiff_salt"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Layer integrated diffusive diapycnal buoyancy flux due to double diffusion of salt.
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"Bflx_dia_diff_idV_ddiff_salt"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: scalar
+    ! long_name: Global integrated diffusive diapycnal buoyancy flux due to double diffusion of salt.
+    ! units: W
+"Bflx_dia_diff_leak"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
+    ! long_name: Diffusive diapycnal buoyancy flux across interfaces due to Kd_leak mixing
+    ! units: W m-3
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+    ! variants: {Bflx_dia_diff_leak,Bflx_dia_diff_leak_xyave}
+"Bflx_dia_diff_dz_leak"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: Layerwise integral of diffusive diapycnal buoyancy flux due to bkgnd mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {Bflx_dia_diff_dz_leak,Bflx_dia_diff_dz_leak_xyave}
+"Bflx_dia_diff_idz_leak"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Layer integrated diffusive diapycnal buoyancy flux due to bkgnd mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"Bflx_dia_diff_idV_leak"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: scalar
+    ! long_name: Global integrated diffusive diapycnal buoyancy flux due to Kd_leak.
+    ! units: W
+"Bflx_dia_diff_quad"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
+    ! long_name: Diffusive diapycnal buoyancy flux across interfaces due to Kd_quad mixing
+    ! units: W m-3
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+    ! variants: {Bflx_dia_diff_quad,Bflx_dia_diff_quad_xyave}
+"Bflx_dia_diff_dz_quad"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: Layerwise integral of diffusive diapycnal buoyancy flux due to bkgnd mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {Bflx_dia_diff_dz_quad,Bflx_dia_diff_dz_quad_xyave}
+"Bflx_dia_diff_idz_quad"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Layer integrated diffusive diapycnal buoyancy flux due to bkgnd mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"Bflx_dia_diff_idV_quad"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: scalar
+    ! long_name: Global integrated diffusive diapycnal buoyancy flux due to Kd_quad.
+    ! units: W
+"Bflx_dia_diff_itidal"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
+    ! long_name: Diffusive diapycnal buoyancy flux across interfaces due to Kd_itidal mixing
+    ! units: W m-3
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+    ! variants: {Bflx_dia_diff_itidal,Bflx_dia_diff_itidal_xyave}
+"Bflx_dia_diff_dz_itidal"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: Layerwise integral of diffusive diapycnal buoyancy flux due to bkgnd mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {Bflx_dia_diff_dz_itidal,Bflx_dia_diff_dz_itidal_xyave}
+"Bflx_dia_diff_idz_itidal"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Layer integrated diffusive diapycnal buoyancy flux due to bkgnd mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"Bflx_dia_diff_idV_itidal"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: scalar
+    ! long_name: Global integrated diffusive diapycnal buoyancy flux due to Kd_itidal.
+    ! units: W
+"Bflx_dia_diff_Froude"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
+    ! long_name: Diffusive diapycnal buoyancy flux across interfaces due to Kd_Froude mixing
+    ! units: W m-3
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+    ! variants: {Bflx_dia_diff_Froude,Bflx_dia_diff_Froude_xyave}
+"Bflx_dia_diff_dz_Froude"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: Layerwise integral of diffusive diapycnal buoyancy flux due to bkgnd mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {Bflx_dia_diff_dz_Froude,Bflx_dia_diff_dz_Froude_xyave}
+"Bflx_dia_diff_idz_Froude"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Layer integrated diffusive diapycnal buoyancy flux due to bkgnd mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"Bflx_dia_diff_idV_Froude"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: scalar
+    ! long_name: Global integrated diffusive diapycnal buoyancy flux due to Kd_Froude.
+    ! units: W
+"Bflx_dia_diff_slope"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
+    ! long_name: Diffusive diapycnal buoyancy flux across interfaces due to Kd_slope mixing
+    ! units: W m-3
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+    ! variants: {Bflx_dia_diff_slope,Bflx_dia_diff_slope_xyave}
+"Bflx_dia_diff_dz_slope"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: Layerwise integral of diffusive diapycnal buoyancy flux due to bkgnd mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {Bflx_dia_diff_dz_slope,Bflx_dia_diff_dz_slope_xyave}
+"Bflx_dia_diff_idz_slope"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Layer integrated diffusive diapycnal buoyancy flux due to bkgnd mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"Bflx_dia_diff_idV_slope"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: scalar
+    ! long_name: Global integrated diffusive diapycnal buoyancy flux due to Kd_slope.
+    ! units: W
+"Bflx_dia_diff_lowmode"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
+    ! long_name: Diffusive diapycnal buoyancy flux across interfaces due to Kd_lowmode mixing
+    ! units: W m-3
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+    ! variants: {Bflx_dia_diff_lowmode,Bflx_dia_diff_lowmode_xyave}
+"Bflx_dia_diff_dz_lowmode"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: Layerwise integral of diffusive diapycnal buoyancy flux due to bkgnd mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {Bflx_dia_diff_dz_lowmode,Bflx_dia_diff_dz_lowmode_xyave}
+"Bflx_dia_diff_idz_lowmode"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Layer integrated diffusive diapycnal buoyancy flux due to bkgnd mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"Bflx_dia_diff_idV_lowmode"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: scalar
+    ! long_name: Global integrated diffusive diapycnal buoyancy flux due to Kd_lowmode.
+    ! units: W
+"Bflx_dia_diff_Niku"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
+    ! long_name: Diffusive diapycnal buoyancy flux across interfaces due to Kd_Niku mixing
+    ! units: W m-3
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+    ! variants: {Bflx_dia_diff_Niku,Bflx_dia_diff_Niku_xyave}
+"Bflx_dia_diff_dz_Niku"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: Layerwise integral of diffusive diapycnal buoyancy flux due to bkgnd mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {Bflx_dia_diff_dz_Niku,Bflx_dia_diff_dz_Niku_xyave}
+"Bflx_dia_diff_idz_Niku"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Layer integrated diffusive diapycnal buoyancy flux due to bkgnd mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"Bflx_dia_diff_idV_Niku"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: scalar
+    ! long_name: Global integrated diffusive diapycnal buoyancy flux due to Kd_Niku.
+    ! units: W
+"Bflx_dia_diff_itides"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
+    ! long_name: Diffusive diapycnal buoyancy flux across interfaces due to Kd_itides mixing
+    ! units: W m-3
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+    ! variants: {Bflx_dia_diff_itides,Bflx_dia_diff_itides_xyave}
+"Bflx_dia_diff_dz_itides"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: Layerwise integral of diffusive diapycnal buoyancy flux due to bkgnd mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {Bflx_dia_diff_dz_itides,Bflx_dia_diff_dz_itides_xyave}
+"Bflx_dia_diff_idz_itides"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Layer integrated diffusive diapycnal buoyancy flux due to bkgnd mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"Bflx_dia_diff_idV_itides"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: scalar
+    ! long_name: Global integrated diffusive diapycnal buoyancy flux due to Kd_itides.
+    ! units: W
 "u_predia"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Zonal velocity before diabatic forcing
     ! units: m s-1
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {u_predia,u_predia_xyave}
 "v_predia"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Meridional velocity before diabatic forcing
     ! units: m s-1
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {v_predia,v_predia_xyave}
 "h_predia"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Layer Thickness before diabatic forcing
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {h_predia,h_predia_xyave}
 "e_predia"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Interface Heights before diabatic forcing
     ! units: m
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {e_predia,e_predia_xyave}
 "temp_predia"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Potential Temperature
     ! units: degC
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {temp_predia,temp_predia_xyave}
 "salt_predia"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Salinity
     ! units: PSU
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {salt_predia,salt_predia_xyave}
 "Kd_interface"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Total diapycnal diffusivity at interfaces
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {Kd_interface,Kd_interface_xyave}
 "Kd_heat"  [Unused] (CMOR equivalent is "difvho")
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Total diapycnal diffusivity for heat at interfaces
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {Kd_heat,Kd_heat_xyave,difvho,difvho_xyave}
 "Kd_salt"  [Unused] (CMOR equivalent is "difvso")
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Total diapycnal diffusivity for salt at interfaces
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {Kd_salt,Kd_salt_xyave,difvso,difvso_xyave}
-"KPP_OBLdepth"  [Unused] (CMOR equivalent is "oml")
+"KPP_OBLdepth"  [Used] (CMOR equivalent is "oml")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Thickness of the surface Ocean Boundary Layer calculated by [CVMix] KPP
     ! units: meter
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {KPP_OBLdepth,oml}
 "KPP_OBLdepth_original"  [Unused] (CMOR equivalent is "oml")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Thickness of the surface Ocean Boundary Layer without smoothing calculated by [CVMix] KPP
     ! units: meter
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {KPP_OBLdepth_original,oml}
 "KPP_BulkDrho"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Bulk difference in density used in Bulk Richardson number, as used by [CVMix] KPP
     ! units: kg/m3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {KPP_BulkDrho,KPP_BulkDrho_xyave}
 "KPP_BulkUz2"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Square of bulk difference in resolved velocity used in Bulk Richardson number via [CVMix] KPP
     ! units: m2/s2
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {KPP_BulkUz2,KPP_BulkUz2_xyave}
 "KPP_BulkRi"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Bulk Richardson number used to find the OBL depth used by [CVMix] KPP
     ! units: nondim
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {KPP_BulkRi,KPP_BulkRi_xyave}
 "KPP_sigma"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Sigma coordinate used by [CVMix] KPP
     ! units: nondim
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {KPP_sigma,KPP_sigma_xyave}
 "KPP_Ws"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Turbulent vertical velocity scale for scalars used by [CVMix] KPP
     ! units: m/s
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {KPP_Ws,KPP_Ws_xyave}
 "KPP_N"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: (Adjusted) Brunt-Vaisala frequency used by [CVMix] KPP
     ! units: 1/s
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {KPP_N,KPP_N_xyave}
 "KPP_N2"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Square of Brunt-Vaisala frequency used by [CVMix] KPP
     ! units: 1/s2
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {KPP_N2,KPP_N2_xyave}
 "KPP_Vt2"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Unresolved shear turbulence used by [CVMix] KPP
     ! units: m2/s2
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {KPP_Vt2,KPP_Vt2_xyave}
 "KPP_uStar"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Friction velocity, u*, as used by [CVMix] KPP
     ! units: m/s
     ! cell_methods: xh:mean yh:mean area:mean
 "KPP_buoyFlux"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Surface (and penetrating) buoyancy flux, as used by [CVMix] KPP
     ! units: m2/s3
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {KPP_buoyFlux,KPP_buoyFlux_xyave}
 "KPP_Kheat"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Heat diffusivity due to KPP, as calculated by [CVMix] KPP
     ! units: m2/s
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {KPP_Kheat,KPP_Kheat_xyave}
 "KPP_Kd_in"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Diffusivity passed to KPP
     ! units: m2/s
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {KPP_Kd_in,KPP_Kd_in_xyave}
 "KPP_Ksalt"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Salt diffusivity due to KPP, as calculated by [CVMix] KPP
     ! units: m2/s
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {KPP_Ksalt,KPP_Ksalt_xyave}
 "KPP_Kv"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Vertical viscosity due to KPP, as calculated by [CVMix] KPP
     ! units: m2/s
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {KPP_Kv,KPP_Kv_xyave}
 "KPP_NLtransport_heat"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Non-local transport (Cs*G(sigma)) for heat, as calculated by [CVMix] KPP
     ! units: nondim
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {KPP_NLtransport_heat,KPP_NLtransport_heat_xyave}
 "KPP_NLtransport_salt"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Non-local tranpsort (Cs*G(sigma)) for scalars, as calculated by [CVMix] KPP
     ! units: nondim
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {KPP_NLtransport_salt,KPP_NLtransport_salt_xyave}
 "KPP_Tsurf"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Temperature of surface layer (10% of OBL depth) as passed to [CVMix] KPP
     ! units: C
     ! cell_methods: xh:mean yh:mean area:mean
 "KPP_Ssurf"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Salinity of surface layer (10% of OBL depth) as passed to [CVMix] KPP
     ! units: ppt
     ! cell_methods: xh:mean yh:mean area:mean
 "KPP_Usurf"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: i-component flow of surface layer (10% of OBL depth) as passed to [CVMix] KPP
     ! units: m/s
     ! cell_methods: xq:point yh:mean
 "KPP_Vsurf"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: j-component flow of surface layer (10% of OBL depth) as passed to [CVMix] KPP
     ! units: m/s
     ! cell_methods: xh:mean yq:point
 "EnhK"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Langmuir number enhancement to K as used by [CVMix] KPP
     ! units: nondim
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {EnhK,EnhK_xyave}
 "EnhVt2"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Langmuir number enhancement to Vt2 as used by [CVMix] KPP
     ! units: nondim
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {EnhVt2,EnhVt2_xyave}
 "KPP_La_SL"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Surface-layer Langmuir number computed in [CVMix] KPP
     ! units: nondim
     ! cell_methods: xh:mean yh:mean area:mean
 "diabatic_diff_h"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Cell thickness used during diabatic diffusion
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {diabatic_diff_h,diabatic_diff_h_xyave}
 "diabatic_diff_temp_tendency"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Diabatic diffusion temperature tendency
     ! units: degC s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {diabatic_diff_temp_tendency,diabatic_diff_temp_tendency_xyave}
 "diabatic_diff_saln_tendency"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Diabatic diffusion salinity tendency
     ! units: psu s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {diabatic_diff_saln_tendency,diabatic_diff_saln_tendency_xyave}
 "diabatic_heat_tendency"  [Unused] (CMOR equivalent is "opottempdiff")
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Diabatic diffusion heat tendency
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {diabatic_heat_tendency,diabatic_heat_tendency_xyave,opottempdiff,opottempdiff_xyave}
 "diabatic_salt_tendency"  [Unused] (CMOR equivalent is "osaltdiff")
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Diabatic diffusion of salt tendency
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {diabatic_salt_tendency,diabatic_salt_tendency_xyave,osaltdiff,osaltdiff_xyave}
 "diabatic_heat_tendency_2d"  [Unused] (CMOR equivalent is "opottempdiff_2d")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Depth integrated diabatic diffusion heat tendency
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {diabatic_heat_tendency_2d,opottempdiff_2d}
 "diabatic_salt_tendency_2d"  [Unused] (CMOR equivalent is "osaltdiff_2d")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Depth integrated diabatic diffusion salt tendency
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {diabatic_salt_tendency_2d,osaltdiff_2d}
 "boundary_forcing_h"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Cell thickness after applying boundary forcing
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {boundary_forcing_h,boundary_forcing_h_xyave}
 "boundary_forcing_h_tendency"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Cell thickness tendency due to boundary forcing
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {boundary_forcing_h_tendency,boundary_forcing_h_tendency_xyave}
 "boundary_forcing_temp_tendency"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Boundary forcing temperature tendency
     ! units: degC s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {boundary_forcing_temp_tendency,boundary_forcing_temp_tendency_xyave}
 "boundary_forcing_saln_tendency"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Boundary forcing saln tendency
     ! units: psu s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {boundary_forcing_saln_tendency,boundary_forcing_saln_tendency_xyave}
 "boundary_forcing_heat_tendency"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Boundary forcing heat tendency
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {boundary_forcing_heat_tendency,boundary_forcing_heat_tendency_xyave}
 "boundary_forcing_salt_tendency"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Boundary forcing salt tendency
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {boundary_forcing_salt_tendency,boundary_forcing_salt_tendency_xyave}
 "boundary_forcing_heat_tendency_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Depth integrated boundary forcing of ocean heat
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "boundary_forcing_salt_tendency_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Depth integrated boundary forcing of ocean salt
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "frazil_h"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Cell Thickness
     ! units: m
     ! standard_name: cell_thickness
@@ -2239,124 +3145,145 @@
     ! variants: {frazil_h,frazil_h_xyave}
 "frazil_temp_tendency"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Temperature tendency due to frazil formation
     ! units: degC s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {frazil_temp_tendency,frazil_temp_tendency_xyave}
 "frazil_heat_tendency"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Heat tendency due to frazil formation
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {frazil_heat_tendency,frazil_heat_tendency_xyave}
 "frazil_heat_tendency_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Depth integrated heat tendency due to frazil formation
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "N2_conv"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Square of Brunt-Vaisala frequency used by MOM_CVMix_conv module
     ! units: 1/s2
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {N2_conv,N2_conv_xyave}
 "kd_conv"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Additional diffusivity added by MOM_CVMix_conv module
     ! units: m2/s
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {kd_conv,kd_conv_xyave}
 "kv_conv"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Additional viscosity added by MOM_CVMix_conv module
     ! units: m2/s
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {kv_conv,kv_conv_xyave}
 "Kd_BBL"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Bottom Boundary Layer Diffusivity
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {Kd_BBL,Kd_BBL_xyave}
 "Kd_bkgnd"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Background diffusivity added by MOM_bkgnd_mixing module
     ! units: m2/s
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {Kd_bkgnd,Kd_bkgnd_xyave}
 "Kv_bkgnd"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Background viscosity added by MOM_bkgnd_mixing module
     ! units: m2/s
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {Kv_bkgnd,Kv_bkgnd_xyave}
 "Kd_layer"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Diapycnal diffusivity of layers (as set)
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {Kd_layer,Kd_layer_xyave}
 "N2_shear"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Square of Brunt-Vaisala frequency used by MOM_CVMix_shear module
     ! units: 1/s2
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {N2_shear,N2_shear_xyave}
 "S2_shear"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Square of vertical shear used by MOM_CVMix_shear module
     ! units: 1/s2
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {S2_shear,S2_shear_xyave}
 "ri_grad_shear"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Gradient Richarson number used by MOM_CVMix_shear module
     ! units: nondim
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {ri_grad_shear,ri_grad_shear_xyave}
 "ri_grad_shear_orig"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Original gradient Richarson number, before smoothing was applied. This is part of the MOM_CVMix_shear module and only available when N_SMOOTH_RI > 0
     ! units: nondim
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {ri_grad_shear_orig,ri_grad_shear_orig_xyave}
 "kd_shear_CVMix"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Vertical diffusivity added by MOM_CVMix_shear module
     ! units: m2/s
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {kd_shear_CVMix,kd_shear_CVMix_xyave}
 "kv_shear_CVMix"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Vertical viscosity added by MOM_CVMix_shear module
     ! units: m2/s
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {kv_shear_CVMix,kv_shear_CVMix_xyave}
 "KT_extra"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Double-diffusive diffusivity for temperature
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {KT_extra,KT_extra_xyave}
 "KS_extra"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Double-diffusive diffusivity for salinity
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {KS_extra,KS_extra_xyave}
 "R_rho"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Double-diffusion density ratio
     ! units: nondim
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {R_rho,R_rho_xyave}
 "created_H"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: The volume flux added to stop the ocean from drying out and becoming negative in depth
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "rsdoabsorb"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Convergence of Penetrative Shortwave Flux in Sea Water Layer
     ! units: W m-2
     ! standard_name: net_rate_of_absorption_of_shortwave_energy_in_ocean_layer
@@ -2364,6 +3291,7 @@
     ! variants: {rsdoabsorb,rsdoabsorb_xyave}
 "rsdo"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Downwelling Shortwave Flux in Sea Water at Grid Cell Upper Interface
     ! units: W m-2
     ! standard_name: downwelling_shortwave_flux_in_sea_water
@@ -2371,829 +3299,865 @@
     ! variants: {rsdo,rsdo_xyave}
 "nonpenSW"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Non-downwelling SW radiation (i.e., SW absorbed in ocean surface with LW,SENS,LAT)
     ! units: W m-2
     ! standard_name: nondownwelling_shortwave_flux_in_sea_water
     ! cell_methods: xh:mean yh:mean area:mean
 "SW_pen"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Penetrating shortwave radiation flux into ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "SW_vis_pen"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Visible penetrating shortwave radiation flux into ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "opac_1"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Opacity for shortwave radiation in band 1, saved as L^-1 tanh(Opacity * L) for L = 10^-10 m
     ! units: m-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {opac_1,opac_1_xyave}
 "KHTR_u"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zi
     ! long_name: Epipycnal tracer diffusivity at zonal faces of tracer cell
     ! units: m2 s-1
     ! cell_methods: xq:point yh:mean zi:point
     ! variants: {KHTR_u,KHTR_u_xyave}
 "KHTR_v"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zi
     ! long_name: Epipycnal tracer diffusivity at meridional faces of tracer cell
     ! units: m2 s-1
     ! cell_methods: xh:mean yq:point zi:point
     ! variants: {KHTR_v,KHTR_v_xyave}
-"KHTR_h"  [Unused] (CMOR equivalent is "diftrelo")
+"KHTR_h"  [Used] (CMOR equivalent is "diftrelo")
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Epipycnal tracer diffusivity at tracer cell center
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {KHTR_h,KHTR_h_xyave,diftrelo,diftrelo_xyave}
 "KHDT_x"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Epipycnal tracer diffusivity operator at zonal faces of tracer cell
     ! units: m2
     ! cell_methods: xq:point yh:mean
 "KHDT_y"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Epipycnal tracer diffusivity operator at meridional faces of tracer cell
     ! units: m2
     ! cell_methods: xh:mean yq:point
 "CFL_lateral_diff"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Grid CFL number for lateral/neutral tracer diffusion
     ! units: nondim
     ! cell_methods: xh:mean yh:mean area:mean
 "volo"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Total volume of liquid ocean
     ! units: m3
     ! standard_name: sea_water_volume
 "zos"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Sea surface height above geoid
     ! units: m
     ! standard_name: sea_surface_height_above_geoid
     ! cell_methods: xh:mean yh:mean area:mean
 "zossq"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Square of sea surface height above geoid
     ! units: m2
     ! standard_name: square_of_sea_surface_height_above_geoid
     ! cell_methods: xh:mean yh:mean area:mean
 "SSH"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Sea Surface Height
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
 "ssh_ga"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area averaged sea surface height
     ! units: m
     ! standard_name: area_averaged_sea_surface_height
-"SSU"  [Unused]
+"SSU"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Sea Surface Zonal Velocity
     ! units: m s-1
     ! cell_methods: xq:point yh:mean
-"SSV"  [Unused]
+"SSV"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Sea Surface Meridional Velocity
     ! units: m s-1
     ! cell_methods: xh:mean yq:point
 "speed"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Sea Surface Speed
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "ssu_east"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Eastward velocity
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "ssv_north"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Northward velocity
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "SST"  [Used] (CMOR equivalent is "tos")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Sea Surface Temperature
     ! units: degC
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {SST,tos}
 "SST_sq"  [Unused] (CMOR equivalent is "tossq")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Sea Surface Temperature Squared
     ! units: degC2
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {SST_sq,tossq}
 "SSS"  [Used] (CMOR equivalent is "sos")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Sea Surface Salinity
     ! units: psu
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {SSS,sos}
 "SSS_sq"  [Unused] (CMOR equivalent is "sossq")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Sea Surface Salinity Squared
     ! units: psu2
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {SSS_sq,sossq}
-"frazil"  [Unused] (CMOR equivalent is "hfsifrazil")
-    ! modules: {ocean_model,ocean_model_d2}
-    ! long_name: Heat from frazil formation
-    ! units: W m-2
-    ! cell_methods: xh:mean yh:mean area:mean
-    ! variants: {frazil,hfsifrazil}
 "salt_deficit"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Salt source in ocean required to supply excessive ice salt fluxes
     ! units: ppt kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
-"Heat_PmE"  [Unused]
+"Heat_PmE"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Heat flux into ocean from mass flux into ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "internal_heat"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Heat flux into ocean from geothermal or other internal sources
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "u_dyn"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Zonal velocity after the dynamics update
     ! units: m s-1
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {u_dyn,u_dyn_xyave}
 "v_dyn"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Meridional velocity after the dynamics update
     ! units: m s-1
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {v_dyn,v_dyn_xyave}
 "h_dyn"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Layer Thickness after the dynamics update
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {h_dyn,h_dyn_xyave}
 "SSH_inst"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Instantaneous Sea Surface Height
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
 "uhtr"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Accumulated zonal thickness fluxes to advect tracers
     ! units: m3
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {uhtr,uhtr_xyave}
 "vhtr"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Accumulated meridional thickness fluxes to advect tracers
     ! units: m3
     ! cell_methods: xh:sum yq:point zl:sum
     ! variants: {vhtr,vhtr_xyave}
-"umo"  [Unused]
+"umo"  [Used]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Ocean Mass X Transport
     ! units: kg s-1
     ! standard_name: ocean_mass_x_transport
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {umo,umo_xyave}
-"vmo"  [Unused]
+"vmo"  [Used]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Ocean Mass Y Transport
     ! units: kg s-1
     ! standard_name: ocean_mass_y_transport
     ! cell_methods: xh:sum yq:point zl:sum
     ! variants: {vmo,vmo_xyave}
-"umo_2d"  [Used]
+"umo_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Ocean Mass X Transport Vertical Sum
     ! units: kg s-1
     ! standard_name: ocean_mass_x_transport_vertical_sum
     ! cell_methods: xq:point yh:sum
-"vmo_2d"  [Used]
+"vmo_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Ocean Mass Y Transport Vertical Sum
     ! units: kg s-1
     ! standard_name: ocean_mass_y_transport_vertical_sum
     ! cell_methods: xh:sum yq:point
 "dynamics_h"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Layer thicknesses prior to horizontal dynamics
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {dynamics_h,dynamics_h_xyave}
 "dynamics_h_tendency"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Change in layer thicknesses due to horizontal dynamics
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {dynamics_h_tendency,dynamics_h_tendency_xyave}
 "temp"  [Used] (CMOR equivalent is "thetao")
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Potential Temperature
     ! units: degC
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {temp,temp_xyave,thetao,thetao_xyave}
 "temp_post_horzn"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Potential Temperature after horizontal transport (advection/diffusion) has occurred
     ! units: degC
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {temp_post_horzn,temp_post_horzn_xyave}
 "T_adx"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Advective (by residual mean) Zonal Flux of Heat
     ! units: W
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {T_adx,T_adx_xyave}
 "T_ady"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Advective (by residual mean) Meridional Flux of Heat
     ! units: W
     ! cell_methods: xh:sum yq:point zl:sum
     ! variants: {T_ady,T_ady_xyave}
 "T_diffx"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Diffusive Zonal Flux of Heat
     ! units: W
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {T_diffx,T_diffx_xyave}
 "T_diffy"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Diffusive Meridional Flux of Heat
     ! units: W
     ! cell_methods: xh:sum yq:point zl:sum
     ! variants: {T_diffy,T_diffy_xyave}
 "T_hbd_diffx"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Horizontal Boundary Diffusive Zonal Flux of Heat
     ! units: W
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {T_hbd_diffx,T_hbd_diffx_xyave}
 "T_hbd_diffy"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Horizontal Boundary Diffusive Meridional Flux of Heat
     ! units: W
     ! cell_methods: xh:sum yq:point zl:sum
     ! variants: {T_hbd_diffy,T_hbd_diffy_xyave}
-"T_adx_2d"  [Unused]
+"T_zint"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Thickness-weighted integral of Potential Temperature
+    ! units: degC m
+    ! cell_methods: xh:mean yh:mean area:mean
+"T_zint_100m"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Thickness-weighted integral of Potential Temperature over top 100m
+    ! units: degC m
+    ! cell_methods: xh:mean yh:mean area:mean
+"T_SURF"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Surface values of Potential Temperature
+    ! units: degC
+    ! cell_methods: xh:mean yh:mean area:mean
+"T_adx_2d"  [Used]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Vertically Integrated Advective Zonal Flux of Heat
     ! units: W
     ! cell_methods: xq:point yh:sum
-"T_ady_2d"  [Unused]
+"T_ady_2d"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Vertically Integrated Advective Meridional Flux of Heat
     ! units: W
     ! cell_methods: xh:sum yq:point
-"T_diffx_2d"  [Unused]
+"T_diffx_2d"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Vertically Integrated Diffusive Zonal Flux of Heat
     ! units: W
     ! cell_methods: xq:point yh:sum
-"T_diffy_2d"  [Unused]
+"T_diffy_2d"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Vertically Integrated Diffusive Meridional Flux of Heat
     ! units: W
     ! cell_methods: xh:sum yq:point
 "T_hbd_diffx_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Vertically-integrated zonal diffusive flux from the horizontal boundary diffusion scheme for Heat
     ! units: W
     ! cell_methods: xq:point yh:sum
 "T_hbd_diffy_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Vertically-integrated meridional diffusive flux from the horizontal boundary diffusion scheme for Heat
     ! units: W
     ! cell_methods: xh:sum yq:point
 "T_advection_xy"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Horizontal convergence of residual mean advective fluxes of heat
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {T_advection_xy,T_advection_xy_xyave}
 "T_advection_xy_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Vertical sum of horizontal convergence of residual mean advective fluxes of heat
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "T_tendency"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Net time tendency for potential temperature
     ! units: degC s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {T_tendency,T_tendency_xyave}
 "T_dfxy_cont_tendency"  [Unused] (CMOR equivalent is "opottemppmdiff")
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Neutral diffusion tracer content tendency for T
     ! units: W m-2
     ! cell_methods: xh:sum yh:sum zl:sum area:sum
     ! variants: {T_dfxy_cont_tendency,T_dfxy_cont_tendency_xyave,opottemppmdiff,opottemppmdiff_xyave}
 "T_dfxy_cont_tendency_2d"  [Unused] (CMOR equivalent is "opottemppmdiff_2d")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Depth integrated neutral diffusion tracer content tendency for T
     ! units: W m-2
     ! cell_methods: xh:sum yh:sum area:sum
     ! variants: {T_dfxy_cont_tendency_2d,opottemppmdiff_2d}
 "T_hbdxy_cont_tendency"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Horizontal boundary diffusion tracer content tendency for T
     ! units: W m-2
     ! cell_methods: xh:sum yh:sum zl:sum area:sum
     ! variants: {T_hbdxy_cont_tendency,T_hbdxy_cont_tendency_xyave}
 "T_hbdxy_cont_tendency_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Depth integrated horizontal boundary diffusion of tracer content tendency for T
     ! units: W m-2
     ! cell_methods: xh:sum yh:sum area:sum
 "T_dfxy_conc_tendency"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Neutral diffusion tracer concentration tendency for T
     ! units: degC s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {T_dfxy_conc_tendency,T_dfxy_conc_tendency_xyave}
 "T_hbdxy_conc_tendency"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Horizontal diffusion tracer concentration tendency for T
     ! units: degC s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {T_hbdxy_conc_tendency,T_hbdxy_conc_tendency_xyave}
 "Th_tendency"  [Unused] (CMOR equivalent is "opottemptend")
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Net time tendency for heat
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {Th_tendency,Th_tendency_xyave,opottemptend,opottemptend_xyave}
 "Th_tendency_2d"  [Unused] (CMOR equivalent is "opottemptend_2d")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Vertical sum of net time tendency for heat
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {Th_tendency_2d,opottemptend_2d}
 "T_tendency_vert_remap"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Vertical remapping tracer concentration tendency for temp
     ! units: degC s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {T_tendency_vert_remap,T_tendency_vert_remap_xyave}
 "Th_tendency_vert_remap"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Vertical remapping tracer content tendency for Heat
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {Th_tendency_vert_remap,Th_tendency_vert_remap_xyave}
 "Th_tendency_vert_remap_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Vertical sum of vertical remapping tracer content tendency for Heat
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "T_vardec"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: ALE variance decay for potential temperature
     ! units: degC2 s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {T_vardec,T_vardec_xyave}
 "KPP_QminusSW"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Net temperature flux ignoring short-wave, as used by [CVMix] KPP
     ! units: degC m s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "KPP_NLT_dTdt"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Potential Temperature tendency due to non-local transport of heat, as calculated by [CVMix] KPP
     ! units: degC s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {KPP_NLT_dTdt,KPP_NLT_dTdt_xyave}
 "KPP_NLT_temp_budget"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Heat content change due to non-local transport, as calculated by [CVMix] KPP
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {KPP_NLT_temp_budget,KPP_NLT_temp_budget_xyave}
 "salt"  [Used] (CMOR equivalent is "so")
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Salinity
     ! units: psu
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {salt,salt_xyave,so,so_xyave}
 "salt_post_horzn"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Salinity after horizontal transport (advection/diffusion) has occurred
     ! units: psu
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {salt_post_horzn,salt_post_horzn_xyave}
 "S_adx"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Advective (by residual mean) Zonal Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {S_adx,S_adx_xyave}
 "S_ady"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Advective (by residual mean) Meridional Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xh:sum yq:point zl:sum
     ! variants: {S_ady,S_ady_xyave}
 "S_diffx"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Diffusive Zonal Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {S_diffx,S_diffx_xyave}
 "S_diffy"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Diffusive Meridional Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xh:sum yq:point zl:sum
     ! variants: {S_diffy,S_diffy_xyave}
 "S_hbd_diffx"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Horizontal Boundary Diffusive Zonal Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {S_hbd_diffx,S_hbd_diffx_xyave}
 "S_hbd_diffy"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Horizontal Boundary Diffusive Meridional Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xh:sum yq:point zl:sum
     ! variants: {S_hbd_diffy,S_hbd_diffy_xyave}
+"S_zint"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Thickness-weighted integral of Salinity
+    ! units: psu m
+    ! cell_methods: xh:mean yh:mean area:mean
+"S_zint_100m"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Thickness-weighted integral of Salinity over top 100m
+    ! units: psu m
+    ! cell_methods: xh:mean yh:mean area:mean
+"S_SURF"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Surface values of Salinity
+    ! units: psu
+    ! cell_methods: xh:mean yh:mean area:mean
 "S_adx_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Vertically Integrated Advective Zonal Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xq:point yh:sum
 "S_ady_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Vertically Integrated Advective Meridional Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xh:sum yq:point
 "S_diffx_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Vertically Integrated Diffusive Zonal Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xq:point yh:sum
 "S_diffy_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Vertically Integrated Diffusive Meridional Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xh:sum yq:point
 "S_hbd_diffx_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Vertically-integrated zonal diffusive flux from the horizontal boundary diffusion scheme for Salt
     ! units: psu m3 s-1
     ! cell_methods: xq:point yh:sum
 "S_hbd_diffy_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Vertically-integrated meridional diffusive flux from the horizontal boundary diffusion scheme for Salt
     ! units: psu m3 s-1
     ! cell_methods: xh:sum yq:point
 "S_advection_xy"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Horizontal convergence of residual mean advective fluxes of salt
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {S_advection_xy,S_advection_xy_xyave}
 "S_advection_xy_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Vertical sum of horizontal convergence of residual mean advective fluxes of salt
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "S_tendency"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Net time tendency for salinity
     ! units: psu s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {S_tendency,S_tendency_xyave}
 "S_dfxy_cont_tendency"  [Unused] (CMOR equivalent is "osaltpmdiff")
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Neutral diffusion tracer content tendency for S
     ! units: kg m-2 s-1
     ! cell_methods: xh:sum yh:sum zl:sum area:sum
     ! variants: {S_dfxy_cont_tendency,S_dfxy_cont_tendency_xyave,osaltpmdiff,osaltpmdiff_xyave}
 "S_dfxy_cont_tendency_2d"  [Unused] (CMOR equivalent is "osaltpmdiff_2d")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Depth integrated neutral diffusion tracer content tendency for S
     ! units: kg m-2 s-1
     ! cell_methods: xh:sum yh:sum area:sum
     ! variants: {S_dfxy_cont_tendency_2d,osaltpmdiff_2d}
 "S_hbdxy_cont_tendency"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Horizontal boundary diffusion tracer content tendency for S
     ! units: kg m-2 s-1
     ! cell_methods: xh:sum yh:sum zl:sum area:sum
     ! variants: {S_hbdxy_cont_tendency,S_hbdxy_cont_tendency_xyave}
 "S_hbdxy_cont_tendency_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Depth integrated horizontal boundary diffusion of tracer content tendency for S
     ! units: kg m-2 s-1
     ! cell_methods: xh:sum yh:sum area:sum
 "S_dfxy_conc_tendency"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Neutral diffusion tracer concentration tendency for S
     ! units: psu s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {S_dfxy_conc_tendency,S_dfxy_conc_tendency_xyave}
 "S_hbdxy_conc_tendency"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Horizontal diffusion tracer concentration tendency for S
     ! units: psu s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {S_hbdxy_conc_tendency,S_hbdxy_conc_tendency_xyave}
 "Sh_tendency"  [Unused] (CMOR equivalent is "osalttend")
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Net time tendency for salt
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {Sh_tendency,Sh_tendency_xyave,osalttend,osalttend_xyave}
 "Sh_tendency_2d"  [Unused] (CMOR equivalent is "osalttend_2d")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Vertical sum of net time tendency for salt
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {Sh_tendency_2d,osalttend_2d}
 "S_tendency_vert_remap"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Vertical remapping tracer concentration tendency for salt
     ! units: psu s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {S_tendency_vert_remap,S_tendency_vert_remap_xyave}
 "Sh_tendency_vert_remap"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Vertical remapping tracer content tendency for Salt
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {Sh_tendency_vert_remap,Sh_tendency_vert_remap_xyave}
 "Sh_tendency_vert_remap_2d"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Vertical sum of vertical remapping tracer content tendency for Salt
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "S_vardec"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: ALE variance decay for salinity
     ! units: psu2 s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {S_vardec,S_vardec_xyave}
 "KPP_netSalt"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Effective net surface salt flux, as used by [CVMix] KPP
     ! units: psu m s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "KPP_NLT_dSdt"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Salinity tendency due to non-local transport of salt, as calculated by [CVMix] KPP
     ! units: psu s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {KPP_NLT_dSdt,KPP_NLT_dSdt_xyave}
 "KPP_NLT_saln_budget"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Salt content change due to non-local transport, as calculated by [CVMix] KPP
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {KPP_NLT_saln_budget,KPP_NLT_saln_budget_xyave}
-"age"  [Used] (CMOR equivalent is "agessc")
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
-    ! long_name: Ideal Age Tracer
-    ! units: yr
-    ! cell_methods: xh:mean yh:mean zl:mean area:mean
-    ! variants: {age,age_xyave,agessc,agessc_xyave}
-"age_post_horzn"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
-    ! long_name: Ideal Age Tracer after horizontal transport (advection/diffusion) has occurred
-    ! units: yr
-    ! cell_methods: xh:mean yh:mean zl:mean area:mean
-    ! variants: {age_post_horzn,age_post_horzn_xyave}
-"age_adx"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
-    ! long_name: Ideal Age Tracer advective zonal flux
-    ! units: yr m3 s-1
-    ! cell_methods: xq:point yh:sum zl:sum
-    ! variants: {age_adx,age_adx_xyave}
-"age_ady"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
-    ! long_name: Ideal Age Tracer advective meridional flux
-    ! units: yr m3 s-1
-    ! cell_methods: xh:sum yq:point zl:sum
-    ! variants: {age_ady,age_ady_xyave}
-"age_dfx"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
-    ! long_name: Ideal Age Tracer diffusive zonal flux
-    ! units: yr m3 s-1
-    ! cell_methods: xq:point yh:sum zl:sum
-    ! variants: {age_dfx,age_dfx_xyave}
-"age_dfy"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
-    ! long_name: Ideal Age Tracer diffusive meridional flux
-    ! units: yr m3 s-1
-    ! cell_methods: xh:sum yq:point zl:sum
-    ! variants: {age_dfy,age_dfy_xyave}
-"age_hbd_diffx"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
-    ! long_name: Ideal Age Tracer diffusive zonal flux from the horizontal boundary diffusion scheme
-    ! units: yr m3 s-1
-    ! cell_methods: xq:point yh:sum zl:sum
-    ! variants: {age_hbd_diffx,age_hbd_diffx_xyave}
-"age_hbd_diffy"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
-    ! long_name: Ideal Age Tracer diffusive meridional flux from the horizontal boundary diffusion scheme
-    ! units: yr m3 s-1
-    ! cell_methods: xh:sum yq:point zl:sum
-    ! variants: {age_hbd_diffy,age_hbd_diffy_xyave}
-"age_adx_2d"  [Unused]
-    ! modules: {ocean_model,ocean_model_d2}
-    ! long_name: Vertically Integrated Advective Zonal Flux of Ideal Age Tracer
-    ! units: yr m3 s-1
-    ! cell_methods: xq:point yh:sum
-"age_ady_2d"  [Unused]
-    ! modules: {ocean_model,ocean_model_d2}
-    ! long_name: Vertically Integrated Advective Meridional Flux of Ideal Age Tracer
-    ! units: yr m3 s-1
-    ! cell_methods: xh:sum yq:point
-"age_diffx_2d"  [Unused]
-    ! modules: {ocean_model,ocean_model_d2}
-    ! long_name: Vertically Integrated Diffusive Zonal Flux of Ideal Age Tracer
-    ! units: yr m3 s-1
-    ! cell_methods: xq:point yh:sum
-"age_diffy_2d"  [Unused]
-    ! modules: {ocean_model,ocean_model_d2}
-    ! long_name: Vertically Integrated Diffusive Meridional Flux of Ideal Age Tracer
-    ! units: yr m3 s-1
-    ! cell_methods: xh:sum yq:point
-"age_hbd_diffx_2d"  [Unused]
-    ! modules: {ocean_model,ocean_model_d2}
-    ! long_name: Vertically-integrated zonal diffusive flux from the horizontal boundary diffusion scheme for Ideal Age Tracer
-    ! units: yr m3 s-1
-    ! cell_methods: xq:point yh:sum
-"age_hbd_diffy_2d"  [Unused]
-    ! modules: {ocean_model,ocean_model_d2}
-    ! long_name: Vertically-integrated meridional diffusive flux from the horizontal boundary diffusion scheme for Ideal Age Tracer
-    ! units: yr m3 s-1
-    ! cell_methods: xh:sum yq:point
-"age_advection_xy"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
-    ! long_name: Horizontal convergence of residual mean advective fluxes of ideal age tracer
-    ! units: yr m s-1
-    ! cell_methods: xh:mean yh:mean zl:sum area:mean
-    ! variants: {age_advection_xy,age_advection_xy_xyave}
-"age_advection_xy_2d"  [Unused]
-    ! modules: {ocean_model,ocean_model_d2}
-    ! long_name: Vertical sum of horizontal convergence of residual mean advective fluxes of ideal age tracer
-    ! units: yr m s-1
-    ! cell_methods: xh:mean yh:mean area:mean
-"age_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
-    ! long_name: Net time tendency for ideal age tracer
-    ! units: yr s-1
-    ! cell_methods: xh:mean yh:mean zl:mean area:mean
-    ! variants: {age_tendency,age_tendency_xyave}
-"age_dfxy_cont_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
-    ! long_name: Neutral diffusion tracer content tendency for age
-    ! units: yr m s-1
-    ! cell_methods: xh:sum yh:sum zl:sum area:sum
-    ! variants: {age_dfxy_cont_tendency,age_dfxy_cont_tendency_xyave}
-"age_dfxy_cont_tendency_2d"  [Unused]
-    ! modules: {ocean_model,ocean_model_d2}
-    ! long_name: Depth integrated neutral diffusion tracer content tendency for age
-    ! units: yr m s-1
-    ! cell_methods: xh:sum yh:sum area:sum
-"age_hbdxy_cont_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
-    ! long_name: Horizontal boundary diffusion tracer content tendency for age
-    ! units: yr m s-1
-    ! cell_methods: xh:sum yh:sum zl:sum area:sum
-    ! variants: {age_hbdxy_cont_tendency,age_hbdxy_cont_tendency_xyave}
-"age_hbdxy_cont_tendency_2d"  [Unused]
-    ! modules: {ocean_model,ocean_model_d2}
-    ! long_name: Depth integrated horizontal boundary diffusion tracer content tendency for age
-    ! units: yr m s-1
-    ! cell_methods: xh:sum yh:sum area:sum
-"age_dfxy_conc_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
-    ! long_name: Neutral diffusion tracer concentration tendency for age
-    ! units: yr s-1
-    ! cell_methods: xh:mean yh:mean zl:mean area:mean
-    ! variants: {age_dfxy_conc_tendency,age_dfxy_conc_tendency_xyave}
-"age_hbdxy_conc_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
-    ! long_name: Horizontal diffusion tracer concentration tendency for age
-    ! units: yr s-1
-    ! cell_methods: xh:mean yh:mean zl:mean area:mean
-    ! variants: {age_hbdxy_conc_tendency,age_hbdxy_conc_tendency_xyave}
-"ageh_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
-    ! long_name: Net time tendency for ideal age tracer
-    ! units: yr m s-1
-    ! cell_methods: xh:mean yh:mean zl:sum area:mean
-    ! variants: {ageh_tendency,ageh_tendency_xyave}
-"ageh_tendency_2d"  [Unused]
-    ! modules: {ocean_model,ocean_model_d2}
-    ! long_name: Vertical sum of net time tendency for ideal age tracer
-    ! units: yr m s-1
-    ! cell_methods: xh:mean yh:mean area:mean
-"age_tendency_vert_remap"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
-    ! long_name: Vertical remapping tracer concentration tendency for age
-    ! units: yr s-1
-    ! cell_methods: xh:mean yh:mean zl:mean area:mean
-    ! variants: {age_tendency_vert_remap,age_tendency_vert_remap_xyave}
-"ageh_tendency_vert_remap"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
-    ! long_name: Vertical remapping tracer content tendency for Ideal Age Tracer
-    ! units: yr m s-1
-    ! cell_methods: xh:mean yh:mean zl:sum area:mean
-    ! variants: {ageh_tendency_vert_remap,ageh_tendency_vert_remap_xyave}
-"ageh_tendency_vert_remap_2d"  [Unused]
-    ! modules: {ocean_model,ocean_model_d2}
-    ! long_name: Vertical sum of vertical remapping tracer content tendency for Ideal Age Tracer
-    ! units: yr m s-1
-    ! cell_methods: xh:mean yh:mean area:mean
-"age_vardec"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
-    ! long_name: ALE variance decay for ideal age tracer
-    ! units: yr2 s-1
-    ! cell_methods: xh:mean yh:mean zl:mean area:mean
-    ! variants: {age_vardec,age_vardec_xyave}
-"KPP_netage"  [Unused]
-    ! modules: {ocean_model,ocean_model_d2}
-    ! long_name: Effective net surface ideal age tracer flux, as used by [CVMix] KPP
-    ! units: yr m s-1
-    ! cell_methods: xh:mean yh:mean area:mean
-"KPP_NLT_dagedt"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
-    ! long_name: Ideal Age Tracer tendency due to non-local transport of ideal age tracer, as calculated by [CVMix] KPP
-    ! units: yr s-1
-    ! cell_methods: xh:mean yh:mean zl:mean area:mean
-    ! variants: {KPP_NLT_dagedt,KPP_NLT_dagedt_xyave}
-"KPP_NLT_age_budget"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
-    ! long_name: Ideal Age Tracer content change due to non-local transport, as calculated by [CVMix] KPP
-    ! units: yr m s-1
-    ! cell_methods: xh:mean yh:mean zl:sum area:mean
-    ! variants: {KPP_NLT_age_budget,KPP_NLT_age_budget_xyave}
 "u_preale"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
     ! long_name: Zonal velocity before remapping
     ! units: m s-1
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {u_preale,u_preale_xyave}
 "v_preale"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
     ! long_name: Meridional velocity before remapping
     ! units: m s-1
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {v_preale,v_preale_xyave}
 "h_preale"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Layer Thickness before remapping
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {h_preale,h_preale_xyave}
 "T_preale"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Temperature before remapping
     ! units: degC
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {T_preale,T_preale_xyave}
 "S_preale"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Salinity before remapping
     ! units: PSU
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {S_preale,S_preale_xyave}
 "e_preale"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Interface Heights before remapping
     ! units: m
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {e_preale,e_preale_xyave}
 "dzRegrid"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
     ! long_name: Change in interface height due to ALE regridding
     ! units: m
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {dzRegrid,dzRegrid_xyave}
 "vert_remap_h"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: layer thicknesses after ALE regridding and remapping
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {vert_remap_h,vert_remap_h_xyave}
 "vert_remap_h_tendency"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
     ! long_name: Layer thicknesses tendency due to ALE regridding and remapping
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {vert_remap_h_tendency,vert_remap_h_tendency_xyave}
+"ale_u2"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
+    ! long_name: Rate of change in half rho0 times depth integral of squared zonal velocity by remapping. If REMAP_VEL_CONSERVE_KE is .true. then  this measures the change before the KE-conserving correction is applied.
+    ! units: W m-2
+    ! cell_methods: xq:point yh:mean
+"ale_v2"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
+    ! long_name: Rate of change in half rho0 times depth integral of squared meridional velocity by remapping. If REMAP_VEL_CONSERVE_KE is .true. then  this measures the change before the KE-conserving correction is applied.
+    ! units: W m-2
+    ! cell_methods: xh:mean yq:point
+"sppt_pattern"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: random pattern for sppt
+    ! units: None
+    ! cell_methods: xh:mean yh:mean area:mean
+"skeb_pattern"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yq
+    ! long_name: random pattern for skeb
+    ! units: None
+    ! cell_methods: xq:point yq:point
+"epbl1_wts"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: random pattern for KE generation
+    ! units: None
+    ! cell_methods: xh:mean yh:mean area:mean
+"epbl2_wts"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: random pattern for KE dissipation
+    ! units: None
+    ! cell_methods: xh:mean yh:mean area:mean
+"skebu"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xq, yh, zl
+    ! long_name: zonal current perts
+    ! units: None
+    ! cell_methods: xq:point yh:mean zl:mean
+    ! variants: {skebu,skebu_xyave}
+"skebv"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yq, zl
+    ! long_name: zonal current perts
+    ! units: None
+    ! cell_methods: xh:mean yq:point zl:mean
+    ! variants: {skebv,skebv_xyave}
+"skeb_amp"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: SKEB amplitude
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {skeb_amp,skeb_amp_xyave}
+"psi"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yq, zl
+    ! long_name: stream function
+    ! units: None
+    ! cell_methods: xq:point yq:point zl:mean
+"skeb_taper_u"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: xq, yh
+    ! long_name: SKEB taper u
+    ! units: None
+"skeb_taper_v"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: xh, yq
+    ! long_name: SKEB taper v
+    ! units: None
 "taux"  [Used] (CMOR equivalent is "tauuo")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xq, yh
     ! long_name: Zonal surface stress from ocean interactions with atmos and ice
     ! units: Pa
     ! standard_name: surface_downward_x_stress
@@ -3201,6 +4165,7 @@
     ! variants: {taux,tauuo}
 "tauy"  [Used] (CMOR equivalent is "tauvo")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yq
     ! long_name: Meridional surface stress ocean interactions with atmos and ice
     ! units: Pa
     ! standard_name: surface_downward_y_stress
@@ -3208,41 +4173,54 @@
     ! variants: {tauy,tauvo}
 "tau_mag"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Average magnitude of the wind stress including contributions from gustiness
     ! units: Pa
     ! cell_methods: xh:mean yh:mean area:mean
-"ustar"  [Unused]
+"ustar"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Surface friction velocity = [(gustiness + tau_magnitude)/rho0]^(1/2)
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean area:mean
+"omega_w2x"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Counter-clockwise angle of the wind stress from the horizontal axis.
+    ! units: rad
+    ! cell_methods: xh:mean yh:mean area:mean
 "p_surf"  [Used] (CMOR equivalent is "pso")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Pressure at ice-ocean or atmosphere-ocean interface
     ! units: Pa
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {p_surf,pso}
 "TKE_tidal"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Tidal source of BBL mixing
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "PRCmE"  [Used] (CMOR equivalent is "wfo")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Net surface water flux (precip+melt+lrunoff+ice calving-evap)
     ! units: kg m-2 s-1
     ! standard_name: water_flux_into_sea_water
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {PRCmE,wfo}
-"evap"  [Unused] (CMOR equivalent is "evs")
+"evap"  [Used] (CMOR equivalent is "evs")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Evaporation/condensation at ocean surface (evaporation is negative)
     ! units: kg m-2 s-1
     ! standard_name: water_evaporation_flux
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {evap,evs}
-"seaice_melt"  [Unused] (CMOR equivalent is "fsitherm")
+"seaice_melt"  [Used] (CMOR equivalent is "fsitherm")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: water flux to ocean from snow/sea ice melting(> 0) or formation(< 0)
     ! units: kg m-2 s-1
     ! standard_name: water_flux_into_sea_water_due_to_sea_ice_thermodynamics
@@ -3250,229 +4228,307 @@
     ! variants: {seaice_melt,fsitherm}
 "precip"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Liquid + frozen precipitation into ocean
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
-"fprec"  [Unused] (CMOR equivalent is "prsn")
+"fprec"  [Used] (CMOR equivalent is "prsn")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Frozen precipitation into ocean
     ! units: kg m-2 s-1
     ! standard_name: snowfall_flux
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {fprec,prsn}
-"lprec"  [Unused] (CMOR equivalent is "prlq")
+"lprec"  [Used] (CMOR equivalent is "prlq")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Liquid precipitation into ocean
     ! units: kg m-2 s-1
     ! standard_name: rainfall_flux
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {lprec,prlq}
-"vprec"  [Unused]
+"vprec"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Virtual liquid precip into ocean due to SSS restoring
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
-"frunoff"  [Unused] (CMOR equivalent is "ficeberg")
+"frunoff"  [Used] (CMOR equivalent is "ficeberg")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Frozen runoff (calving) and iceberg melt into ocean
     ! units: kg m-2 s-1
     ! standard_name: water_flux_into_sea_water_from_icebergs
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {frunoff,ficeberg}
-"lrunoff"  [Unused] (CMOR equivalent is "friver")
+"lrunoff"  [Used] (CMOR equivalent is "friver")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Liquid runoff (rivers) into ocean
     ! units: kg m-2 s-1
     ! standard_name: water_flux_into_sea_water_from_rivers
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {lrunoff,friver}
+"frunoff_glc"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Frozen glacier runoff (calving) and iceberg melt into ocean
+    ! units: kg m-2 s-1
+    ! standard_name: glc_water_flux_into_sea_water_from_icebergs
+    ! cell_methods: xh:mean yh:mean area:mean
+"lrunoff_glc"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Liquid runoff (glaciers) into ocean
+    ! units: kg m-2 s-1
+    ! standard_name: water_flux_into_sea_water_from_glaciers
+    ! cell_methods: xh:mean yh:mean area:mean
 "net_massout"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Net mass leaving the ocean due to evaporation, seaice formation
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "net_massin"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Net mass entering ocean due to precip, runoff, ice melt
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "massout_flux"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Net mass flux of freshwater out of the ocean (used in the boundary flux calculation)
     ! units: kg m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "massin_flux"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Net mass flux of freshwater into the ocean (used in boundary flux calculation)
     ! units: kg m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "total_PRCmE"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated net surface water flux (precip+melt+liq runoff+ice calving-evap)
     ! units: kg s-1
     ! standard_name: water_flux_into_sea_water_area_integrated
     ! variants: {total_PRCmE,total_wfo}
 "total_evap"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated evap/condense at ocean surface
     ! units: kg s-1
     ! standard_name: water_evaporation_flux_area_integrated
     ! variants: {total_evap,total_evs}
 "total_icemelt"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated sea ice melt (>0) or form (<0)
     ! units: kg s-1
     ! standard_name: water_flux_into_sea_water_due_to_sea_ice_thermodynamics_area_integrated
     ! variants: {total_icemelt,total_fsitherm}
-"total_precip"  [Used]
+"total_precip"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated liquid+frozen precip into ocean
     ! units: kg s-1
 "total_fprec"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated frozen precip into ocean
     ! units: kg s-1
     ! standard_name: snowfall_flux_area_integrated
     ! variants: {total_fprec,total_prsn}
-"total_lprec"  [Used]
+"total_lprec"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated liquid precip into ocean
     ! units: kg s-1
     ! standard_name: rainfall_flux_area_integrated
     ! variants: {total_lprec,total_pr}
 "total_vprec"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated virtual liquid precip due to SSS restoring
     ! units: kg s-1
 "total_frunoff"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated frozen runoff (calving) & iceberg melt into ocean
     ! units: kg s-1
     ! variants: {total_frunoff,total_ficeberg}
 "total_lrunoff"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated liquid runoff into ocean
     ! units: kg s-1
     ! variants: {total_lrunoff,total_friver}
-"total_net_massout"  [Used]
+"total_frunoff_glc"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
+    ! long_name: Area integrated frozen glacier runoff (calving) & iceberg melt into ocean
+    ! units: kg s-1
+"total_lrunoff_glc"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: scalar
+    ! long_name: Area integrated liquid glacier runoff into ocean
+    ! units: kg s-1
+"total_net_massout"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated mass leaving ocean due to evap and seaice form
     ! units: kg s-1
-"total_net_massin"  [Used]
+"total_net_massin"  [Unused]
     ! modules: ocean_model
-    ! long_name: Area integrated mass entering ocean due to predip, runoff, ice melt
+    ! dimensions: scalar
+    ! long_name: Area integrated mass entering ocean due to precip, runoff, ice melt
     ! units: kg s-1
 "PRCmE_ga"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area averaged net surface water flux (precip+melt+liq runoff+ice calving-evap)
     ! units: kg m-2 s-1
     ! standard_name: water_flux_into_sea_water_area_averaged
     ! variants: {PRCmE_ga,ave_wfo}
 "evap_ga"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area averaged evap/condense at ocean surface
     ! units: kg m-2 s-1
     ! standard_name: water_evaporation_flux_area_averaged
     ! variants: {evap_ga,ave_evs}
 "lprec_ga"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated liquid precip into ocean
     ! units: kg m-2 s-1
     ! standard_name: rainfall_flux_area_averaged
     ! variants: {lprec_ga,ave_pr}
 "fprec_ga"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated frozen precip into ocean
     ! units: kg m-2 s-1
     ! standard_name: snowfall_flux_area_averaged
     ! variants: {fprec_ga,ave_prsn}
 "precip_ga"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area averaged liquid+frozen precip into ocean
     ! units: kg m-2 s-1
 "vrec_ga"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area averaged virtual liquid precip due to SSS restoring
     ! units: kg m-2 s-1
-"heat_content_frunoff"  [Unused]
+"heat_content_frunoff"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Heat content (relative to 0C) of solid runoff into ocean
     ! units: W m-2
     ! standard_name: temperature_flux_due_to_solid_runoff_expressed_as_heat_flux_into_sea_water
     ! cell_methods: xh:mean yh:mean area:mean
-"heat_content_lrunoff"  [Unused]
+"heat_content_lrunoff"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Heat content (relative to 0C) of liquid runoff into ocean
     ! units: W m-2
     ! standard_name: temperature_flux_due_to_runoff_expressed_as_heat_flux_into_sea_water
     ! cell_methods: xh:mean yh:mean area:mean
-"hfrunoffds"  [Used]
+"heat_content_frunoff_glc"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Heat content (relative to 0C) of solid glacier runoff into ocean
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"heat_content_lrunoff_glc"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Heat content (relative to 0C) of liquid glacier runoff into ocean
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"hfrunoffds"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Heat content (relative to 0C) of liquid+solid runoff into ocean
     ! units: W m-2
     ! standard_name: temperature_flux_due_to_runoff_expressed_as_heat_flux_into_sea_water
     ! cell_methods: xh:mean yh:mean area:mean
-"heat_content_lprec"  [Unused]
+"heat_content_lprec"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Heat content (relative to 0degC) of liquid precip entering ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
-"heat_content_fprec"  [Unused]
+"heat_content_fprec"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Heat content (relative to 0degC) of frozen prec entering ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
-"heat_content_vprec"  [Unused]
+"heat_content_vprec"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Heat content (relative to 0degC) of virtual precip entering ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
-"heat_content_cond"  [Unused]
+"heat_content_cond"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Heat content (relative to 0degC) of water condensing into ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
-"heat_content_evap"  [Unused]
+"heat_content_evap"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Heat content (relative to 0degC) of water evaporating from ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
-"hfrainds"  [Used]
+"hfrainds"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Heat content (relative to 0degC) of liquid+frozen precip entering ocean
     ! units: W m-2
     ! standard_name: temperature_flux_due_to_rainfall_expressed_as_heat_flux_into_sea_water
     ! cell_methods: xh:mean yh:mean area:mean
 "heat_content_surfwater"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Heat content (relative to 0degC) of net water crossing ocean surface (frozen+liquid)
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "heat_content_massout"  [Unused] (CMOR equivalent is "hfevapds")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Heat content (relative to 0degC) of net mass leaving ocean ocean via evap and ice form
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {heat_content_massout,hfevapds}
 "heat_content_massin"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Heat content (relative to 0degC) of net mass entering ocean ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
-"net_heat_coupler"  [Used]
+"net_heat_coupler"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Surface ocean heat flux from SW+LW+latent+sensible+seaice_melt_heat (via the coupler)
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "net_heat_surface"  [Used] (CMOR equivalent is "hfds")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Surface ocean heat flux from SW+LW+lat+sens+mass transfer+frazil+restore+seaice_melt_heat or flux adjustments
     ! units: W m-2
     ! standard_name: surface_downward_heat_flux_in_sea_water
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {net_heat_surface,hfds}
-"SW"  [Unused] (CMOR equivalent is "rsntds")
+"SW"  [Used] (CMOR equivalent is "rsntds")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Shortwave radiation flux into ocean
     ! units: W m-2
     ! standard_name: net_downward_shortwave_flux_at_sea_water_surface
@@ -3480,254 +4536,328 @@
     ! variants: {SW,rsntds}
 "sw_vis"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Shortwave radiation direct and diffuse flux into the ocean in the visible band
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "sw_nir"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Shortwave radiation direct and diffuse flux into the ocean in the near-infrared band
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "LwLatSens"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Combined longwave, latent, and sensible heating at ocean surface
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
-"LW"  [Unused] (CMOR equivalent is "rlntds")
+"LW"  [Used] (CMOR equivalent is "rlntds")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Longwave radiation flux into ocean
     ! units: W m-2
     ! standard_name: surface_net_downward_longwave_flux
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {LW,rlntds}
-"latent"  [Unused] (CMOR equivalent is "hflso")
+"latent"  [Used] (CMOR equivalent is "hflso")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Latent heat flux into ocean due to fusion and evaporation (negative means ocean heat loss)
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {latent,hflso}
 "latent_evap"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Latent heat flux into ocean due to evaporation/condensation
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
-"latent_fprec_diag"  [Unused] (CMOR equivalent is "hfsnthermds")
+"latent_fprec_diag"  [Used] (CMOR equivalent is "hfsnthermds")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Latent heat flux into ocean due to melting of frozen precipitation
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {latent_fprec_diag,hfsnthermds}
 "latent_frunoff"  [Unused] (CMOR equivalent is "hfibthermds")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Latent heat flux into ocean due to melting of icebergs
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {latent_frunoff,hfibthermds}
-"sensible"  [Unused] (CMOR equivalent is "hfsso")
+"latent_frunoff_glc"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Latent heat flux into ocean due to melting of frozen glacier runoff
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"sensible"  [Used] (CMOR equivalent is "hfsso")
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Sensible heat flux into ocean
     ! units: W m-2
     ! standard_name: surface_downward_sensible_heat_flux
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {sensible,hfsso}
-"seaice_melt_heat"  [Unused]
+"seaice_melt_heat"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Heat flux into ocean due to snow and sea ice melt/freeze
     ! units: W m-2
     ! standard_name: snow_ice_melt_heat_flux
     ! cell_methods: xh:mean yh:mean area:mean
 "heat_added"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Flux Adjustment or restoring surface heat flux into ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "total_heat_content_frunoff"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated heat content (relative to 0C) of solid runoff
     ! units: W
     ! variants: {total_heat_content_frunoff,total_hfsolidrunoffds}
 "total_heat_content_lrunoff"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated heat content (relative to 0C) of liquid runoff
     ! units: W
     ! variants: {total_heat_content_lrunoff,total_hfrunoffds}
+"total_heat_content_frunoff_glc"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: scalar
+    ! long_name: Area integrated heat content (relative to 0C) of solid glacier runoff
+    ! units: W
+"total_heat_content_lrunoff_glc"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: scalar
+    ! long_name: Area integrated heat content (relative to 0C) of liquid glacier runoff
+    ! units: W
 "total_heat_content_lprec"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated heat content (relative to 0C) of liquid precip
     ! units: W
     ! variants: {total_heat_content_lprec,total_hfrainds}
 "total_heat_content_fprec"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated heat content (relative to 0C) of frozen precip
     ! units: W
 "total_heat_content_vprec"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated heat content (relative to 0C) of virtual precip
     ! units: W
 "total_heat_content_cond"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated heat content (relative to 0C) of condensate
     ! units: W
 "total_heat_content_evap"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated heat content (relative to 0C) of evaporation
     ! units: W
 "total_heat_content_surfwater"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated heat content (relative to 0C) of water crossing surface
     ! units: W
 "total_heat_content_massout"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated heat content (relative to 0C) of water leaving ocean
     ! units: W
     ! variants: {total_heat_content_massout,total_hfevapds}
 "total_heat_content_massin"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated heat content (relative to 0C) of water entering ocean
     ! units: W
 "total_net_heat_coupler"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated surface heat flux from SW+LW+latent+sensible+seaice_melt_heat (via the coupler)
     ! units: W
 "total_net_heat_surface"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated surface heat flux from SW+LW+lat+sens+mass+frazil+restore or flux adjustments
     ! units: W
     ! variants: {total_net_heat_surface,total_hfds}
 "total_sw"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated net downward shortwave at sea water surface
     ! units: W
     ! variants: {total_sw,total_rsntds}
 "total_LwLatSens"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated longwave+latent+sensible heating
     ! units: W
 "total_lw"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated net downward longwave at sea water surface
     ! units: W
     ! variants: {total_lw,total_rlntds}
 "total_lat"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated surface downward latent heat flux
     ! units: W
     ! variants: {total_lat,total_hflso}
 "total_lat_evap"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated latent heat flux due to evap/condense
     ! units: W
 "total_lat_fprec"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated latent heat flux due to melting frozen precip
     ! units: W
     ! variants: {total_lat_fprec,total_hfsnthermds}
 "total_lat_frunoff"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated latent heat flux due to melting icebergs
     ! units: W
     ! variants: {total_lat_frunoff,total_hfibthermds}
+"total_lat_frunoff_glc"  [Unused]
+    ! modules: ocean_model
+    ! dimensions: scalar
+    ! long_name: Area integrated latent heat flux due to melting frozen glacier runoff
+    ! units: W
 "total_sens"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated downward sensible heat flux
     ! units: W
     ! variants: {total_sens,total_hfsso}
 "total_heat_adjustment"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated surface heat flux from restoring and/or flux adjustment
     ! units: W
 "total_seaice_melt_heat"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated surface heat flux from snow and sea ice melt
     ! units: W
 "net_heat_coupler_ga"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area averaged surface heat flux from SW+LW+latent+sensible+seaice_melt_heat (via the coupler)
     ! units: W m-2
 "net_heat_surface_ga"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area averaged surface heat flux from SW+LW+lat+sens+mass+frazil+restore+seaice_melt_heat or flux adjustments
     ! units: W m-2
     ! variants: {net_heat_surface_ga,ave_hfds}
 "sw_ga"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area averaged net downward shortwave at sea water surface
     ! units: W m-2
     ! variants: {sw_ga,ave_rsntds}
 "LwLatSens_ga"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area averaged longwave+latent+sensible heating
     ! units: W m-2
 "lw_ga"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area averaged net downward longwave at sea water surface
     ! units: W m-2
     ! variants: {lw_ga,ave_rlntds}
 "lat_ga"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area averaged surface downward latent heat flux
     ! units: W m-2
     ! variants: {lat_ga,ave_hflso}
 "sens_ga"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area averaged downward sensible heat flux
     ! units: W m-2
     ! variants: {sens_ga,ave_hfsso}
 "salt_flux"  [Used] (CMOR equivalent is "sfdsi")
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Net salt flux into ocean at surface (restoring + sea-ice)
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {salt_flux,sfdsi}
-"salt_flux_in"  [Used]
+"salt_flux_in"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Salt flux into ocean at surface from coupler
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "salt_flux_added"  [Used]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Salt flux into ocean at surface due to restoring or flux adjustment
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "salt_left_behind"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
     ! long_name: Salt left in ocean at surface due to ice formation
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
-"salt_flux_global_restoring_adjustment"  [Used]
+"salt_flux_global_restoring_adjustment"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Adjustment needed to balance net global salt flux into ocean at surface
     ! units: kg m-2 s-1
 "vprec_global_adjustment"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Adjustment needed to adjust net vprec into ocean to zero
     ! units: kg m-2 s-1
-"net_fresh_water_global_adjustment"  [Used]
+"net_fresh_water_global_adjustment"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Adjustment needed to adjust net fresh water into ocean to zero
     ! units: kg m-2 s-1
 "salt_flux_global_restoring_scaling"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Scaling applied to balance net global salt flux into ocean at surface
     ! units: nondim
 "vprec_global_scaling"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Scaling applied to adjust net vprec into ocean to zero
     ! units: nondim
 "net_fresh_water_global_scaling"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Scaling applied to adjust net fresh water into ocean to zero
     ! units: nondim
-"total_salt_flux"  [Used]
+"total_salt_flux"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated surface salt flux
     ! units: kg s-1
     ! variants: {total_salt_flux,total_sfdsi}
-"total_salt_Flux_In"  [Used]
+"total_salt_Flux_In"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated surface salt flux at surface from coupler
     ! units: kg s-1
-"total_salt_Flux_Added"  [Used]
+"total_salt_Flux_Added"  [Unused]
     ! modules: ocean_model
+    ! dimensions: scalar
     ! long_name: Area integrated surface salt flux due to restoring or flux adjustment
     ! units: kg s-1

--- a/field_table
+++ b/field_table
@@ -1,10 +1,8 @@
 # WOMBATlite field table
 # ===============================================
-"namelists","ocean_mod","generic_wombatlite/"
+"namelists","ocean_mod","generic_wombatlite/*global*"
 /
 "namelists","ocean_mod","generic_wombatlite"
-init = t
-#
 no3_src_file = INPUT/init_tracers_mod.nc
 no3_src_var_name = no3
 no3_src_var_unit = none
@@ -112,10 +110,7 @@ det_sediment_dest_var_unit = mol m-2
 det_sediment_src_var_record = 1
 det_sediment_src_var_gridspec = NONE
 det_sediment_valid_min = 0.0
-
-/
-###.................................................
-"namelists","ocean_mod","generic_wombatlite"
+#
 no3_obc_src_file_name = obgc_obc.nc
 no3_obc_src_field_name = no3
 no3_obc_has = .True.

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -2,7 +2,7 @@ format: yamanifest
 version: 1.0
 ---
 work/access-om3-MOM6:
-  fullpath: /g/data/vk83/prerelease/apps/spack/0.22/release/linux-rocky8-x86_64/intel-2021.10.0/access-om3-nuopc-git.0.4.1_0.4.1-mdludj4azhygq3p2mrfytygz5lgzintj/bin/access-om3-MOM6
+  fullpath: /g/data/vk83/prerelease/apps/spack/0.22/release/linux-rocky8-x86_64_v4/oneapi-2025.2.0/access3-2025.08.000-se6hjna4ahyhygz7fnfv2jeaku4getwk/bin/access-om3-MOM6
   hashes:
-    binhash: 9759335d147c0115e2d04d06a9ce7656
-    md5: 8f61d02172b86bfe53b6687539cacecf
+    binhash: 13372e83b0e5cd4f100aedb5a0a9cad2
+    md5: 59723b91a198e3f3e8e2f32377760512

--- a/manifests/input.yaml
+++ b/manifests/input.yaml
@@ -11,6 +11,11 @@ work/INPUT/JRA55do-drof-ESMFmesh.nc:
   hashes:
     binhash: fa1322dbc0ab951527b165f8327c7b5b
     md5: 3b46260b8c14d12925cf70f82da6658e
+work/INPUT/SFe_Hamiltonetal2020_monthly_clim.nc:
+  fullpath: /g/data/ol01/ee8016/regional_wombat/SFe_Hamiltonetal2020_monthly_clim.nc
+  hashes:
+    binhash: 6114f49dcf9b6a5915683154af95d5c5
+    md5: c40f8b268d113f10a28269e611caf709
 work/INPUT/access-rom3-ESMFmesh.nc:
   fullpath: /g/data/ol01/ee8016/regional_wombat/access-rom3-ESMFmesh.nc
   hashes:
@@ -3386,11 +3391,6 @@ work/INPUT/bathymetry.nc:
   hashes:
     binhash: ba82a01f837a995c272b0f43a315bfc3
     md5: 2639cdb91c8e7bec43c8dd74943e24a6
-work/INPUT/dust_DS.nc:
-  fullpath: /g/data/ol01/ee8016/regional_wombat/dust_DS.nc
-  hashes:
-    binhash: 5a63e9526ff1a285e7ce992c83cd5c19
-    md5: 149ed14ffc73f8908fa1f8e84146c6bc
 work/INPUT/grid_spec.nc:
   fullpath: /g/data/ol01/ee8016/regional_wombat/grid_spec.nc
   hashes:

--- a/nuopc.runconfig
+++ b/nuopc.runconfig
@@ -27,28 +27,24 @@ DRIVER_attributes::
 ::
 
 PELAYOUT_attributes::
-     atm_ntasks = 24
+     atm_ntasks = 16
      atm_nthreads = 1
      atm_pestride = 1
      atm_rootpe = 0
-     cpl_ntasks = 24
+     cpl_ntasks = 16
      cpl_nthreads = 1
      cpl_pestride = 1
      cpl_rootpe = 0
      esmf_logging = ESMF_LOGKIND_NONE
-     ice_ntasks = 24
-     ice_nthreads = 1
-     ice_pestride = 1
-     ice_rootpe = 0
      ninst = 1
-     ocn_ntasks = 240
+     ocn_ntasks = 192
      ocn_nthreads = 1
      ocn_pestride = 1
-     ocn_rootpe = 0
+     ocn_rootpe = 16
      pio_asyncio_ntasks = 0
      pio_asyncio_rootpe = 1
      pio_asyncio_stride = 0
-     rof_ntasks = 24
+     rof_ntasks = 16
      rof_nthreads = 1
      rof_pestride = 1
      rof_rootpe = 0


### PR DESCRIPTION
This PR includes the following fixes/updates:

- [x] Remove the `init` param from the `field_table`. This had been incorrectly set to true at some point in the setting up of this configuration. This is what was causing the non-sensical co2 fluxes. I've removed `init` from the `field_table` to try and avoid this being incorrectly set in the future. (We should probably just remove it from WOMBAT.).
- [x] Fixed an error in the `field_table` where the `"generic_wombatlite"` namelist was being defined twice.
- [x] Update to `access-om3/pr144-1` which is the same as the recent `access-om3@2025.08.000` release but uses WOMBAT legacy. This includes modifications to run on the Sapphire Rapids nodes.
- [x] Update the iron forcing to use [Hamilton et al 2020 data](https://doi.org/10.7298/xqqj-qk90).