### PR TITLE
100km ryf config: Add parameterisations for tidal dissipation (#562)

### DIFF
--- a/MOM_input
+++ b/MOM_input
@@ -517,6 +517,36 @@ USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
                                 ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
                                 ! scheme.
 
+! === module MOM_tidal_mixing ===
+! Vertical Tidal Mixing Parameterization
+INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
+INT_TIDE_PROFILE = "POLZIN_09"  ! default = "STLAURENT_02"
+                                ! INT_TIDE_PROFILE selects the vertical profile of energy dissipation with
+                                ! INT_TIDE_DISSIPATION. Valid values are:
+                                !    STLAURENT_02 - Use the St. Laurent et al exponential
+                                !                   decay profile.
+                                !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
+                                !                   decay profile.
+INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
+KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
+KAPPA_H2_FACTOR = 0.84          !   [nondim] default = 1.0
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
+TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
+READ_TIDEAMP = True             !   [Boolean] default = False
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
+H2_FILE = "bottom_roughness.nc" !
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
+
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
 PRANDTL_BKGND = 5.0             !   [nondim] default = 1.0

--- a/config.yaml
+++ b/config.yaml
@@ -35,6 +35,8 @@ input:
     - /g/data/vk83/configurations/inputs/access-om3/share/meshes/global.100km/2024.01.25/access-om2-100km-nomask-ESMFmesh.nc
     - /g/data/vk83/configurations/inputs/access-om3/share/meshes/share/2024.09.16/JRA55do-datm-ESMFmesh.nc
     - /g/data/vk83/configurations/inputs/access-om3/share/meshes/share/2024.09.16/JRA55do-drof-ESMFmesh.nc
+    - /g/data/vk83/prerelease/configurations/inputs/access-om3/mom/tidal_external_files/global.100km/2025.09.22/bottom_roughness.nc
+    - /g/data/vk83/prerelease/configurations/inputs/access-om3/mom/tidal_external_files/global.100km/2025.09.22/tideamp.nc
     - /g/data/vk83/configurations/inputs/access-om3/share/grids/global.100km/2020.10.22/topog.nc
     - /g/data/vk83/configurations/inputs/access-om3/mom/grids/mosaic/global.100km/2020.05.30/ocean_hgrid.nc
     - /g/data/vk83/prerelease/configurations/inputs/access-om3/mom/grids/vertical/share/2025.03.12/ocean_vgrid.nc

--- a/docs/MOM_parameter_doc.all
+++ b/docs/MOM_parameter_doc.all
@@ -1909,9 +1909,87 @@ SET_DIFF_ANSWER_DATE = 99991231 ! default = 99991231
 ! Vertical Tidal Mixing Parameterization
 USE_CVMix_TIDAL = False         !   [Boolean] default = False
                                 ! If true, turns on tidal mixing via CVMix
-INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
+INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
                                 ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
                                 ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
+TIDAL_MIXING_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the tidal mixing
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use updated and more robust forms of the same expressions.
+INT_TIDE_PROFILE = "POLZIN_09"  ! default = "STLAURENT_02"
+                                ! INT_TIDE_PROFILE selects the vertical profile of energy dissipation with
+                                ! INT_TIDE_DISSIPATION. Valid values are:
+                                !    STLAURENT_02 - Use the St. Laurent et al exponential
+                                !                   decay profile.
+                                !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
+                                !                   decay profile.
+LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
+                                ! If true, use an lee wave driven dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of Nikurashin (2010) and using the St. Laurent et al. (2002)
+                                ! and Simmons et al. (2004) vertical profile
+INT_TIDE_LOWMODE_DISSIPATION = False !   [Boolean] default = False
+                                ! If true, consider mixing due to breaking low modes that have been remotely
+                                ! generated; as with itidal drag on the barotropic tide, use an internal tidal
+                                ! dissipation scheme to drive diapycnal mixing, along the lines of St. Laurent
+                                ! et al. (2002) and Simmons et al. (2004).
+NU_POLZIN = 0.0697              !   [nondim] default = 0.0697
+                                ! When the Polzin decay profile is used, this is a non-dimensional constant in
+                                ! the expression for the vertical scale of decay for the tidal energy
+                                ! dissipation.
+NBOTREF_POLZIN = 9.61E-04       !   [s-1] default = 9.61E-04
+                                ! When the Polzin decay profile is used, this is the reference value of the
+                                ! buoyancy frequency at the ocean bottom in the Polzin formulation for the
+                                ! vertical scale of decay for the tidal energy dissipation.
+POLZIN_DECAY_SCALE_FACTOR = 1.0 !   [nondim] default = 1.0
+                                ! When the Polzin decay profile is used, this is a scale factor for the vertical
+                                ! scale of decay of the tidal energy dissipation.
+POLZIN_SCALE_MAX_FACTOR = 1.0   !   [nondim] default = 1.0
+                                ! When the Polzin decay profile is used, this is a factor to limit the vertical
+                                ! scale of decay of the tidal energy dissipation to
+                                ! POLZIN_DECAY_SCALE_MAX_FACTOR times the depth of the ocean.
+POLZIN_MIN_DECAY_SCALE = 0.0    !   [m] default = 0.0
+                                ! When the Polzin decay profile is used, this is the minimum vertical decay
+                                ! scale for the vertical profile
+                                ! of internal tide dissipation with the Polzin (2009) formulation
+INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
+MU_ITIDES = 0.2                 !   [nondim] default = 0.2
+                                ! A dimensionless turbulent mixing efficiency used with INT_TIDE_DISSIPATION,
+                                ! often 0.2.
+GAMMA_ITIDES = 0.3333           !   [nondim] default = 0.3333
+                                ! The fraction of the internal tidal energy that is dissipated locally with
+                                ! INT_TIDE_DISSIPATION. THIS NAME COULD BE BETTER.
+MIN_ZBOT_ITIDES = 0.0           !   [m] default = 0.0
+                                ! Turn off internal tidal dissipation when the total ocean depth is less than
+                                ! this value.
+KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
+UTIDE = 0.0                     !   [m s-1] default = 0.0
+                                ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
+KAPPA_H2_FACTOR = 0.84          !   [nondim] default = 1.0
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
+TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
+READ_TIDEAMP = True             !   [Boolean] default = False
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
+TIDEAMP_FILE = "tideamp.nc"     ! default = "tideamp.nc"
+                                ! The path to the file containing the spatially varying tidal amplitudes with
+                                ! INT_TIDE_DISSIPATION.
+TIDEAMP_VARNAME = "tideamp"     ! default = "tideamp"
+                                ! The name of the tidal amplitude variable in the input file.
+H2_FILE = "bottom_roughness.nc" !
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
+ROUGHNESS_VARNAME = "h2"        ! default = "h2"
+                                ! The name in the input file of the squared sub-grid-scale topographic roughness
+                                ! amplitude variable.
+FRACTIONAL_ROUGHNESS_MAX = 0.1  !   [nondim] default = 0.1
+                                ! The maximum topographic roughness amplitude as a fraction of the mean depth,
+                                ! or a negative value for no limitations on roughness.
 ML_RADIATION = False            !   [Boolean] default = False
                                 ! If true, allow a fraction of TKE available from wind work to penetrate below
                                 ! the base of the mixed layer with a vertical decay scale determined by the
@@ -1943,6 +2021,10 @@ LOTW_BBL_ANSWER_DATE = 20190101 ! default = 20190101
 DZ_BBL_AVG_MIN = 0.0            !   [m] default = 0.0
                                 ! A minimal distance over which to average to determine the average bottom
                                 ! boundary layer density.
+SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -2373,11 +2455,6 @@ MASK_SRESTORE = False           !   [Boolean] default = False
                                 ! If true, read a file (salt_restore_mask) containing a mask for SSS restoring.
 CD_TIDES = 1.0E-04              !   [nondim] default = 1.0E-04
                                 ! The drag coefficient that applies to the tides.
-READ_TIDEAMP = False            !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
-                                ! with INT_TIDE_DISSIPATION.
-UTIDE = 0.0                     !   [m s-1] default = 0.0
-                                ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 READ_GUST_2D = False            !   [Boolean] default = False
                                 ! If true, use a 2-dimensional gustiness supplied from an input file
 GUST_CONST = 0.02               !   [Pa] default = 0.0

--- a/docs/MOM_parameter_doc.short
+++ b/docs/MOM_parameter_doc.short
@@ -485,6 +485,36 @@ CVMix_CONVECTION%
 %CVMix_CONVECTION
 
 ! === module MOM_set_diffusivity ===
+
+! === module MOM_tidal_mixing ===
+! Vertical Tidal Mixing Parameterization
+INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
+INT_TIDE_PROFILE = "POLZIN_09"  ! default = "STLAURENT_02"
+                                ! INT_TIDE_PROFILE selects the vertical profile of energy dissipation with
+                                ! INT_TIDE_DISSIPATION. Valid values are:
+                                !    STLAURENT_02 - Use the St. Laurent et al exponential
+                                !                   decay profile.
+                                !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
+                                !                   decay profile.
+INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
+                                ! The decay scale away from the bottom for tidal TKE with the new coding when
+                                ! INT_TIDE_DISSIPATION is used.
+KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION. The default is 2pi/10
+                                ! km, as in St.Laurent et al. 2002.
+KAPPA_H2_FACTOR = 0.84          !   [nondim] default = 1.0
+                                ! A scaling factor for the roughness amplitude with INT_TIDE_DISSIPATION.
+TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
+                                ! The maximum internal tide energy source available to mix above the bottom
+                                ! boundary layer with INT_TIDE_DISSIPATION.
+READ_TIDEAMP = True             !   [Boolean] default = False
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
+H2_FILE = "bottom_roughness.nc" !
+                                ! The path to the file containing the sub-grid-scale topographic roughness
+                                ! amplitude with INT_TIDE_DISSIPATION.
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the BBL mixing and the other
                                 ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.

--- a/docs/available_diags.000000
+++ b/docs/available_diags.000000
@@ -3160,6 +3160,91 @@
     ! units: m2/s
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {kv_conv,kv_conv_xyave}
+"Kd_itides"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
+    ! long_name: Internal Tide Driven Diffusivity
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+    ! variants: {Kd_itides,Kd_itides_xyave}
+"TKE_itidal"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Internal Tide Driven Turbulent Kinetic Energy
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"Nb"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Bottom Buoyancy Frequency
+    ! units: s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"Kd_lowmode"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
+    ! long_name: Internal Tide Driven Diffusivity (from propagating low modes)
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+    ! variants: {Kd_lowmode,Kd_lowmode_xyave}
+"Fl_itides"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
+    ! long_name: Vertical flux of tidal turbulent dissipation
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+    ! variants: {Fl_itides,Fl_itides_xyave}
+"Fl_lowmode"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
+    ! long_name: Vertical flux of tidal turbulent dissipation (from propagating low modes)
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+    ! variants: {Fl_lowmode,Fl_lowmode_xyave}
+"Polzin_decay_scale"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Vertical decay scale for the tidal turbulent dissipation with Polzin scheme
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"Polzin_decay_scale_scaled"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Vertical decay scale for the tidal turbulent dissipation with Polzin scheme, scaled by N2_bot/N2_meanz
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"N2_b"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Bottom Buoyancy frequency squared
+    ! units: s-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"N2_meanz"  [Unused]
+    ! modules: {ocean_model,ocean_model_d2}
+    ! dimensions: xh, yh
+    ! long_name: Buoyancy frequency squared averaged over the water column
+    ! units: s-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"Kd_Itidal_Work"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: Work done by Internal Tide Diapycnal Mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {Kd_Itidal_Work,Kd_Itidal_Work_xyave}
+"Kd_Nikurashin_Work"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: Work done by Nikurashin Lee Wave Drag Scheme
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {Kd_Nikurashin_Work,Kd_Nikurashin_Work_xyave}
+"Kd_Lowmode_Work"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: Work done by Internal Tide Diapycnal Mixing (low modes)
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {Kd_Lowmode_Work,Kd_Lowmode_Work_xyave}
 "Kd_BBL"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
     ! dimensions: xh, yh, zi
@@ -3188,6 +3273,41 @@
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {Kd_layer,Kd_layer_xyave}
+"Kd_Work"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: Work done by Diapycnal Mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {Kd_Work,Kd_Work_xyave}
+"Kd_Work_added"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: Work done by additional mixing Kd_add
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {Kd_Work_added,Kd_Work_added_xyave}
+"maxTKE"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: Maximum layer TKE
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {maxTKE,maxTKE_xyave}
+"TKE_to_Kd"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zl
+    ! long_name: Convert TKE to Kd
+    ! units: s2 m
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+    ! variants: {TKE_to_Kd,TKE_to_Kd_xyave}
+"N2"  [Unused] (CMOR equivalent is "obvfsq")
+    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! dimensions: xh, yh, zi
+    ! long_name: Buoyancy frequency squared
+    ! units: s-2
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+    ! variants: {N2,N2_xyave,obvfsq,obvfsq_xyave}
 "N2_shear"  [Unused]
     ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
     ! dimensions: xh, yh, zi

--- a/manifests/input.yaml
+++ b/manifests/input.yaml
@@ -76,6 +76,11 @@ work/INPUT/access-om2-100km-nomask-ESMFmesh.nc:
   hashes:
     binhash: 38605aedd850ec5c9d208258f2030166
     md5: 9b7120a42b5cb587492e7c31791eb549
+work/INPUT/bottom_roughness.nc:
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-om3/mom/tidal_external_files/global.100km/2025.09.22/bottom_roughness.nc
+  hashes:
+    binhash: e28f832d8cf239fb52e8a835047c9529
+    md5: 014f9b95036b9e5a54a24e3643de675b
 work/INPUT/iced.1900-01-01-10800.nc:
   fullpath: /g/data/vk83/configurations/inputs/access-om3/cice/initial_conditions/global.100km/2023.07.28/iced.1900-01-01-10800.nc
   hashes:
@@ -106,6 +111,11 @@ work/INPUT/salt_sfc_restore.nc:
   hashes:
     binhash: 425ccc4989dc3e1acdecc6ffd7e9a870
     md5: b2bd35c44017597ba99b85fb61ed4d72
+work/INPUT/tideamp.nc:
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-om3/mom/tidal_external_files/global.100km/2025.09.22/tideamp.nc
+  hashes:
+    binhash: 10931d9f5303f728e1bf796b8736613a
+    md5: 9bcd9d203632a58221a53b3f7ca51622
 work/INPUT/topog.nc:
   fullpath: /g/data/vk83/configurations/inputs/access-om3/share/grids/global.100km/2020.10.22/topog.nc
   hashes:

--- a/testing/checksum/historical-6hr-checksum.json
+++ b/testing/checksum/historical-6hr-checksum.json
@@ -2,88 +2,88 @@
   "schema_version": "1-0-0",
   "output": {
     "CAu": [
-      "A45DE955F3887D45"
+      "87727D2F4CD4F990"
     ],
     "CAv": [
-      "E918688D0DF7C9D5"
+      "2CB2D688E54E6C77"
     ],
     "DTBT": [
-      "4055967FC232CB07"
+      "4055967FC282945A"
     ],
     "First_direction": [
       "0"
     ],
     "Kd_shear": [
-      "8C2079A3F693ECCE"
+      "961125BFA77B9AB5"
     ],
     "Kv_shear": [
-      "CCA57DAB42728004"
+      "6FB45ADD7AEC7F54"
     ],
     "MEKE": [
-      "F9A26ED248D97D54"
+      "F7CDB12E1D0D4618"
     ],
     "MEKE_Kh": [
-      "6144C3ADBC5E12E6"
+      "CF5B41D8936F88C6"
     ],
     "MEKE_Kh_diff": [
-      "298FC85454AAF4E3"
+      "4F818FED4ED19150"
     ],
     "MEKE_Ku": [
-      "C99585752A403F64"
+      "1227E05C540DBD28"
     ],
     "MLD_MLE_filtered": [
-      "6DFC44B5FD777883"
+      "67978221B68AD8AC"
     ],
     "Salt": [
-      "29CB318E4C84166D"
+      "581A49642A5178B5"
     ],
     "Temp": [
-      "49AAA80B70B2320A"
+      "57E05CEB4D9D0237"
     ],
     "age": [
-      "86B873D617C6ACE2"
+      "88B827CB850AC3F5"
     ],
     "ave_ssh": [
-      "46760EF5DAB1F5DD"
+      "467DC7D8B945A359"
     ],
     "diffu": [
-      "69A17CCF76829A9F"
+      "538C36EF42F9521"
     ],
     "diffv": [
-      "7012601DA5E7C58F"
+      "D0B99628C3925FFE"
     ],
     "frazil": [
-      "4D9E6C5C68B43E7B"
+      "4B0A4B3A52B3BC79"
     ],
     "h": [
-      "23E922C589E7E87"
+      "2334E046BACC650"
     ],
     "h_ML": [
-      "A8F4D89653BE54B4"
+      "9A8FCDDD2983F5F5"
     ],
     "p_surf_EOS": [
       "15625563E8141921"
     ],
     "sfc": [
-      "4A6B54BE26CA1FC5"
+      "C5BF0707C4D66EC3"
     ],
     "u": [
-      "750B4CA62AF83E09"
+      "AB2A6CF42E3621A0"
     ],
     "u2": [
-      "78C72040D2E26674"
+      "1CEB0574435EE650"
     ],
     "ubtav": [
-      "2CFC7F214D7B50"
+      "FA23712C02D5A33A"
     ],
     "v": [
-      "5A345BDA38B400E0"
+      "F914E5F564BA61E3"
     ],
     "v2": [
-      "9DDCC65709566994"
+      "E077DEE37EEFF33B"
     ],
     "vbtav": [
-      "D18601E6FFB6D6B4"
+      "4DFC1B4816C1C7C6"
     ]
   }
 }


### PR DESCRIPTION
<!-- use these prompts for changes to configuration branhces, skip them for main branch changes -->
**1. Summary**:
Ref: https://github.com/ACCESS-NRI/access-om3-configs/issues/771#issuecomment-3310434280
What has changed?
MOM_input, docs, docs/available_diags.000000, manifests/input.yaml

**2. Issues Addressed:**
<!-- Add links to github issue(s) this is related to -->
- https://github.com/ACCESS-NRI/access-om3-configs/issues/771#issuecomment-3310434280

**3. Dependencies (e.g. on payu, model or om3-scripts)**

This change requires changes to (note required version where true):
- [ ] payu:
- [ ] access-om3:
- [ ] om3-scripts:
<!-- Describe and link to the related changes to dependencies -->

**4. Ad-hoc Testing**

What ad-hoc testing was done? How are you convinced this change is correct (plots are good)?

**5. CI Testing**
<!-- Has the CI-testing been run? -->
- [x] `!test repro` has been run

**6. Reproducibility**

Is this reproducible with the previous commit? (If not, why not?)
- [ ] Yes
- [x] No - `!test repro commit` has been run. <!-- add detail below for why it's answer changing --> 

**7. Documentation**
<!--Does this impact documentation? Has the wiki been updated? Have the `docs/MOM_*` files been updated ?-->

The docs folder has been updated with output from running the model?
- [x] Yes
- [ ] N/A

A PR has been created for updating the documentation?
- [ ] Yes: <!--link-->
- [ ] N/A

**8. Formatting**
<!-- Are changes to MOM_input in the same order as docs/MOM_parameter_docs.short? -->

Changes to MOM_input have been copied from model output in docs/MOM_parameter_docs.short?
- [x] Yes
- [ ] N/A

**9. Merge Strategy**
<!-- What is the planned merge strategy (Merge commit, Rebase and merge, or squash) ?
If not squash, link to the related issue in the commit descriptions -->

- [x] Merge commit
- [ ] Rebase and merge
- [ ] Squash
