### PR TITLE
Bump mkdocs-include-stubs-plugin

### DIFF
--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -3,5 +3,5 @@ mkdocs-git-revision-date-localized-plugin==1.2.0
 mkdocs-macros-plugin==1.0.4
 mkdocs-bibtex==4.4.0
 pypandoc_binary==1.15
+mkdocs-include-stubs-plugin==1.0.2
 git+https://github.com/rbeucher/mkdocs_events_plugin.git
-git+https://github.com/ACCESS-NRI/mkdocs_include_stubs_plugin.git


### PR DESCRIPTION
Bumped mkdocs-include-stubs-plugin to version `1.0.2`.
Selected specific version, which is usually better than downloading it from GitHub repository's `main` branch.